### PR TITLE
Refactor - step 3 (class styles)

### DIFF
--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -106,16 +106,16 @@ int main(int argc, char *argv[])
   //return 0;
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
 /*
   // Fe
   material = new materialBase(7.87); // rho
-  element = new elementBase;
-  element->z = 26; // Fe
-  element->m = 56.0;
-  element->t = 1.0;
-  element->Edisp = 40.0;
+  element = new ElementBase;
+  element->_Z = 26; // Fe
+  element->_m = 56.0;
+  element->_t = 1.0;
+  element->_Edisp = 40.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
@@ -123,11 +123,11 @@ int main(int argc, char *argv[])
 
   // Cu
   material = new materialBase(simconf, 8.94); // rho
-  element = new elementBase;
-  element->z = 29; // Fe
-  element->m = 63.0;
-  element->t = 1.0;
-  element->Edisp = 40.0;
+  element = new ElementBase;
+  element->_Z = 29; // Fe
+  element->_m = 63.0;
+  element->_t = 1.0;
+  element->_Edisp = 40.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
@@ -135,53 +135,53 @@ int main(int argc, char *argv[])
 /*
   // ZrO2
   material = new materialBase(5.68); // rho
-  element = new elementBase;
-  element->z = 40; // Zr
-  element->m = 91.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 40; // Zr
+  element->_m = 91.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
 
   // TiO2 precipitate
   material = new materialBase(4.23); // rho
-  element = new elementBase;
-  element->z = 22; // Ti
-  element->m = 48.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 22; // Ti
+  element->_m = 48.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample
 
    // Y2Ti2O7 precipitate
   material = new materialBase(4.6); // rho between 4.23 and 5.01
-  element = new elementBase;
-  element->z = 39; // Y
-  element->m = 89.0;
-  element->t = 2.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 39; // Y
+  element->_m = 89.0;
+  element->_t = 2.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 22; // Ti
-  element->m = 48.0;
-  element->t = 2.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 22; // Ti
+  element->_m = 48.0;
+  element->_t = 2.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 7.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 7.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample
@@ -189,25 +189,25 @@ int main(int argc, char *argv[])
 /*
   // xe bubble
   material = new materialBase(3.5); // rho
-  element = new elementBase;
-  element->z = 54; // Xe
-  element->m = 132.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 54; // Xe
+  element->_m = 132.0;
+  element->_t = 1.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample
 */
   // TiB2 precipitate
   material = new materialBase(simconf, 4.52); // rho
-  element = new elementBase;
-  element->z = 22; // Ti
-  element->m = 48.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 22; // Ti
+  element->_m = 48.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 5; // B
-  element->m = 11.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 5; // B
+  element->_m = 11.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
   Real r = atof(argv[2]); //10.0;
   Real Cbf = atof(argv[3]);
 
-  sample->bc[0] = sampleBase::INF; // no PBC in x (just clusterless matrix)
+  sample->bc[0] = SampleBase::INF; // no PBC in x (just clusterless matrix)
   sample->initSpatialhash(int(sample->w[0] / r) - 1,
                            int(sample->w[1] / r) - 1,
                            int(sample->w[2] / r) - 1);
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
           {
             dif[i] =  sample->c[i][pka->tag] - pka->pos(i);
             pos2[i] = pka->pos(i);
-            if (sample->bc[i] == sampleBase::PBC) dif[i] -= round(dif[i] / sample->w[i]) * sample->w[i];
+            if (sample->bc[i] == SampleBase::PBC) dif[i] -= round(dif[i] / sample->w[i]) * sample->w[i];
             pos1[i] = pka->pos(i) + dif[i];
             //printf("%f\t%f\t%f\n",   sample->c[i][pka->tag], pka->pos(i), pos1[i]);
           }

--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -105,12 +105,12 @@ int main(int argc, char *argv[])
   fprintf(stderr, "sample built.\n");
   //return 0;
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
 /*
   // Fe
-  material = new materialBase(7.87); // rho
+  material = new MaterialBase(7.87); // rho
   element = new ElementBase;
   element->_Z = 26; // Fe
   element->_m = 56.0;
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
 */
 
   // Cu
-  material = new materialBase(simconf, 8.94); // rho
+  material = new MaterialBase(simconf, 8.94); // rho
   element = new ElementBase;
   element->_Z = 29; // Fe
   element->_m = 63.0;
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
 
 /*
   // ZrO2
-  material = new materialBase(5.68); // rho
+  material = new MaterialBase(5.68); // rho
   element = new ElementBase;
   element->_Z = 40; // Zr
   element->_m = 91.0;
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // TiO2 precipitate
-  material = new materialBase(4.23); // rho
+  material = new MaterialBase(4.23); // rho
   element = new ElementBase;
   element->_Z = 22; // Ti
   element->_m = 48.0;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
    // Y2Ti2O7 precipitate
-  material = new materialBase(4.6); // rho between 4.23 and 5.01
+  material = new MaterialBase(4.6); // rho between 4.23 and 5.01
   element = new ElementBase;
   element->_Z = 39; // Y
   element->_m = 89.0;
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
 */
 /*
   // xe bubble
-  material = new materialBase(3.5); // rho
+  material = new MaterialBase(3.5); // rho
   element = new ElementBase;
   element->_Z = 54; // Xe
   element->_m = 132.0;
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 */
   // TiB2 precipitate
-  material = new materialBase(simconf, 4.52); // rho
+  material = new MaterialBase(simconf, 4.52); // rho
   element = new ElementBase;
   element->_Z = 22; // Ti
   element->_m = 48.0;

--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -68,9 +68,9 @@ int main(int argc, char *argv[])
   // initialize trim engine for the sample
   snprintf(fname, 199, "%s.phon", argv[1]);
   //FILE *phon = fopen(fname, "wt");
-  //trimPhononOut *trim = new trimPhononOut(sample, phon);
-  trimBase *trim = new trimBase(simconf, sample);
-  //trimBase *trim = new trimPrimaries(sample);
+  //TrimPhononOut *trim = new TrimPhononOut(sample, phon);
+  TrimBase *trim = new TrimBase(simconf, sample);
+  //TrimBase *trim = new TrimPrimaries(sample);
 
 
   //Real r = 10.0;

--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_ODS.C
+++ b/apps/mytrim_ODS.C
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
 
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real dif[3], dif2[3];
 
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
 
   Real pos1[3], pos2[3];
 
-  ionMDtag *ff1, *pka;
+  IonMDTag *ff1, *pka;
 
   Real A = 84.0, E = 1.8e6; int Z = 36; // 1.8MeV Kr
   //Real A = 58.0, E = 5.0e6; int Z = 28; // 5MeV Ni
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
   {
     if (n % 10 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionMDtag;
+    ff1 = new IonMDTag;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->md = 0;
@@ -257,12 +257,12 @@ int main(int argc, char *argv[])
     ff1->pos(1) = sample->w[1] / 2.0;
     ff1->pos(2) = sample->w[2] / 2.0;
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
     while (!recoils.empty())
     {
-      pka = dynamic_cast<ionMDtag*>(recoils.front());
+      pka = dynamic_cast<IonMDTag*>(recoils.front());
       recoils.pop();
       sample->averages(pka);
 

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
   Real s_sam = sample->w[1] * sample->w[2];
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   const char *choice[4] = {"Fe", "Si", "Cu", "Au"};
   int i;
@@ -91,13 +91,13 @@ int main(int argc, char *argv[])
     case 0:
       // Fe
       material = new materialBase(simconf, 7.87); // rho
-      element = new elementBase;
+      element = new ElementBase;
       Z = 26.0;
       A = 56.0;
-      element->z = Z;
-      element->m = A;
-      element->t = 1.0;
-      element->Edisp = 25.0;
+      element->_Z = Z;
+      element->_m = A;
+      element->_t = 1.0;
+      element->_Edisp = 25.0;
       material->element.push_back(element);
       material->prepare(); // all materials added
       sample->material.push_back(material); // add material to sample
@@ -105,13 +105,13 @@ int main(int argc, char *argv[])
     case 1:
       // Si
       material = new materialBase(simconf, 2.33); // rho
-      element = new elementBase;
+      element = new ElementBase;
       Z = 14.0;
       A = 28.0;
-      element->z = Z;
-      element->m = A;
-      element->t = 1.0;
-      element->Edisp = 25.0;
+      element->_Z = Z;
+      element->_m = A;
+      element->_t = 1.0;
+      element->_Edisp = 25.0;
       material->element.push_back(element);
       material->prepare(); // all materials added
       sample->material.push_back(material); // add material to sample
@@ -119,13 +119,13 @@ int main(int argc, char *argv[])
     case 2:
       // Cu
       material = new materialBase(simconf, 8.89); // rho
-      element = new elementBase;
+      element = new ElementBase;
       Z = 29.0;
       A = 63.5;
-      element->z = Z;
-      element->m = A;
-      element->t = 1.0;
-      element->Edisp = 25.0;
+      element->_Z = Z;
+      element->_m = A;
+      element->_t = 1.0;
+      element->_Edisp = 25.0;
       material->element.push_back(element);
       material->prepare(); // all materials added
       sample->material.push_back(material); // add material to sample
@@ -133,13 +133,13 @@ int main(int argc, char *argv[])
     case 3:
       // Au
       material = new materialBase(simconf, 19.32); // rho
-      element = new elementBase;
+      element = new ElementBase;
       Z = 79.0;
       A = 197.0;
-      element->z = Z;
-      element->m = A;
-      element->t = 1.0;
-      element->Edisp = 25.0;
+      element->_Z = Z;
+      element->_m = A;
+      element->_t = 1.0;
+      element->_Edisp = 25.0;
       material->element.push_back(element);
       material->prepare(); // all materials added
       sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -67,8 +67,8 @@ int main(int argc, char *argv[])
   SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
   // initialize trim engine for the sample
-  trimBase *trim = new trimBase(simconf, sample);
-  //trimBase *trim = new trimPrimaries(sample);
+  TrimBase *trim = new TrimBase(simconf, sample);
+  //TrimBase *trim = new TrimPrimaries(sample);
 
   //sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
 

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
   Real v_sam = sample->w[0] * sample->w[1] * sample->w[2];
   Real s_sam = sample->w[1] * sample->w[2];
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   const char *choice[4] = {"Fe", "Si", "Cu", "Au"};
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
   switch (i) {
     case 0:
       // Fe
-      material = new materialBase(simconf, 7.87); // rho
+      material = new MaterialBase(simconf, 7.87); // rho
       element = new ElementBase;
       Z = 26.0;
       A = 56.0;
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
       break;
     case 1:
       // Si
-      material = new materialBase(simconf, 2.33); // rho
+      material = new MaterialBase(simconf, 2.33); // rho
       element = new ElementBase;
       Z = 14.0;
       A = 28.0;
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
       break;
     case 2:
       // Cu
-      material = new materialBase(simconf, 8.89); // rho
+      material = new MaterialBase(simconf, 8.89); // rho
       element = new ElementBase;
       Z = 29.0;
       A = 63.5;
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
       break;
     case 3:
       // Au
-      material = new materialBase(simconf, 19.32); // rho
+      material = new MaterialBase(simconf, 19.32); // rho
       element = new ElementBase;
       Z = 79.0;
       A = 197.0;

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -64,13 +64,13 @@ int main(int argc, char *argv[])
   //simconf->tmin = 0.2;
 
   // initialize sample structure
-  sampleSolid *sample = new sampleSolid(200.0, 200.0, 200.0);
+  SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
   // initialize trim engine for the sample
   trimBase *trim = new trimBase(simconf, sample);
   //trimBase *trim = new trimPrimaries(sample);
 
-  //sample->bc[0] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
+  //sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
 
   // Real atp = 0.1; // 10at% Mo 90at%Cu
   Real v_sam = sample->w[0] * sample->w[1] * sample->w[2];

--- a/apps/mytrim_bobmsq.C
+++ b/apps/mytrim_bobmsq.C
@@ -150,10 +150,10 @@ int main(int argc, char *argv[])
 
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real pos2[3];
-  ionBase *ff1, *pka;
+  IonBase *ff1, *pka;
 
   // squared displacement
   Real sqd = 0.0, sqd2 = 0.0;
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
   {
     if (n % 10 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionBase;
+    ff1 = new IonBase;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->id = simconf->id++;
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     ff1->pos(1) = sample->w[1] / 2.0;
     ff1->pos(2) = sample->w[2] / 2.0;
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
     while (!recoils.empty())

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -66,9 +66,9 @@ int main(int argc, char *argv[])
   snprintf(fname, 199, "%s.phon", argv[1]);
 
   //FILE *phon = fopen(fname, "wt");
-  //trimPhononOut *trim = new trimPhononOut(sample, phon);
-  trimBase *trim = new trimBase(simconf, sample);
-  //trimBase *trim = new trimPrimaries(sample);
+  //TrimPhononOut *trim = new TrimPhononOut(sample, phon);
+  TrimBase *trim = new TrimBase(simconf, sample);
+  //TrimBase *trim = new TrimPrimaries(sample);
 
 
   //Real r = 10.0;

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -99,30 +99,30 @@ int main(int argc, char *argv[])
   fprintf(stderr, "sample built.\n");
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   // UO2
   material = new materialBase(simconf, 10.0); // rho
-  element = new elementBase;
-  element->z = 92; // U
-  element->m = 235.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 92; // U
+  element->_m = 235.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 16; // O
-  element->m = 32.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 16; // O
+  element->_m = 32.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
 
   // xe bubble
   material = new materialBase(simconf, 3.5); // rho
-  element = new elementBase;
-  element->z = 54; // Xe
-  element->m = 132.0;
-  element->t = 1.0;
-//  element->t = 0.002;
+  element = new ElementBase;
+  element->_Z = 54; // Xe
+  element->_m = 132.0;
+  element->_t = 1.0;
+//  element->_t = 0.002;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 //  sample->material.push_back(material); // add material to sample
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real norm;
   Real dif[3], dif2[3];
@@ -148,14 +148,14 @@ int main(int argc, char *argv[])
 
   Real pos1[3], pos2[3];
 
-  ionMDtag *ff1, *ff2, *pka;
+  IonMDTag *ff1, *ff2, *pka;
 
   // 1000 fission events
   for (int n = 0; n < 1000; n++) // 2000 ff
   {
     if (n % 10 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionMDtag;
+    ff1 = new IonMDTag;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->md = 0;
@@ -203,10 +203,10 @@ int main(int argc, char *argv[])
       for (int i = 0; i < 3; i++) ff1->pos(i) = dr250() * sample->w[i];
     } while (sample->lookupCluster(ff1->pos) >= 0);
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
-    ff2 = new ionMDtag(*ff1); // copy constructor
+    ff2 = new IonMDTag(*ff1); // copy constructor
     //ff1->id = simconf->id++;
 
     // reverse direction
@@ -216,14 +216,14 @@ int main(int argc, char *argv[])
     ff2->_m = A2;
     ff2->e  = E2 * 1.0e6;
 
-    ff2->set_ef();
+    ff2->setEf();
     recoils.push(ff2);
 
     //fprintf(stderr, "A1=%f Z1=%d (%f MeV)\tA2=%f Z2=%d (%f MeV)\n", A1, Z1, E1, A2, Z2, E2);
 
     while (!recoils.empty())
     {
-      pka = dynamic_cast<ionMDtag*>(recoils.front());
+      pka = dynamic_cast<IonMDTag*>(recoils.front());
       recoils.pop();
       sample->averages(pka);
 

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
 

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
           {
             dif[i] =  sample->c[i][pka->tag] - pka->pos(i);
             pos2[i] = pka->pos(i);
-            if (sample->bc[i] == sampleBase::PBC) dif[i] -= round(dif[i] / sample->w[i]) * sample->w[i];
+            if (sample->bc[i] == SampleBase::PBC) dif[i] -= round(dif[i] / sample->w[i]) * sample->w[i];
 	    pos1[i] = pka->pos(i) + dif[i];
 	    //printf("%f\t%f\t%f\n",   sample->c[i][pka->tag], pka->pos(i), pos1[i]);
           }

--- a/apps/mytrim_clusters.C
+++ b/apps/mytrim_clusters.C
@@ -98,11 +98,11 @@ int main(int argc, char *argv[])
 
   fprintf(stderr, "sample built.\n");
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   // UO2
-  material = new materialBase(simconf, 10.0); // rho
+  material = new MaterialBase(simconf, 10.0); // rho
   element = new ElementBase;
   element->_Z = 92; // U
   element->_m = 235.0;
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // xe bubble
-  material = new materialBase(simconf, 3.5); // rho
+  material = new MaterialBase(simconf, 3.5); // rho
   element = new ElementBase;
   element->_Z = 54; // Xe
   element->_m = 132.0;

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
   std::cout << "n_layers=" << nlayer << std::endl;
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   for (int i = 0; i < nlayer; i++)
   {
@@ -95,11 +95,11 @@ int main(int argc, char *argv[])
 
     for (int j = 0; j < nelem; j++)
     {
-      element = new elementBase;
-      std::cin >> lename >> element->z >> element->m >> element->t;
+      element = new ElementBase;
+      std::cin >> lename >> element->_Z >> element->_m >> element->_t;
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-      std::cout << "  Element: " << lename << "  Z=" << element->z
-           << "  m=" << element->m << "  fraction=" << element->t << std::endl;
+      std::cout << "  Element: " << lename << "  Z=" << element->_Z
+           << "  m=" << element->_m << "  fraction=" << element->_t << std::endl;
       material->element.push_back(element);
     }
     std::cout << material << std::endl;
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
     std::cout << sample->layerThickness[i] << ' ';
     for (unsigned int j = 0; j < sample->material[i]->element.size(); j++)
     {
-      std::cout << sample->material[i]->element[j]->z << ' ' << sample->material[i]->element[j]->t << ' ';
+      std::cout << sample->material[i]->element[j]->_Z << ' ' << sample->material[i]->element[j]->_t << ' ';
     }
     std::cout << std::endl;
   }

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
   }
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   // Real A = 74.0, E = 1.0e5; int Z = 36; // 100keV Kr
   // Real A = 131.0, E = 3.0e4; int Z = 54; // 30keV Xe
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
   snprintf(fname, 199, "%s.dist", argv[1]);
   FILE *rdist = fopen(fname, "wt");
 
-  ionBase *ff1, *pka;
+  IonBase *ff1, *pka;
   int layer1, layer2;
 
   int nrec = 0;
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
   {
     if (n % 100 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionBase;
+    ff1 = new IonBase;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->id = simconf->id++;
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
     ff1->pos(1) = sample->w[1] / 2.0;
     ff1->pos(2) = sample->w[2] / 2.0;
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
     while (!recoils.empty())

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   std::cout << "n_layers=" << nlayer << std::endl;
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   for (int i = 0; i < nlayer; i++)
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     std::cout << "Layer: " << lename << "  d=" << lthick << "Ang  rho="
          << lrho << "g/ccm  n_elements=" << nelem << std::endl;
 
-    material = new materialBase(simconf, lrho); // rho
+    material = new MaterialBase(simconf, lrho); // rho
 
     for (int j = 0; j < nelem; j++)
     {

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   std::cout << "SS " << sx << ' ' << sy << ' ' << sz << std::endl;
 
-  sampleDynamic *sample = new sampleDynamic(simconf, sx, sy, sz);
+  SampleDynamic *sample = new SampleDynamic(simconf, sx, sy, sz);
   trimBase *trim = new trimBase(simconf, sample);
 
   // Read Materials description from stdin

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
   std::cout << "SS " << sx << ' ' << sy << ' ' << sz << std::endl;
 
   SampleDynamic *sample = new SampleDynamic(simconf, sx, sy, sz);
-  trimBase *trim = new trimBase(simconf, sample);
+  TrimBase *trim = new TrimBase(simconf, sample);
 
   // Read Materials description from stdin
   int nlayer;

--- a/apps/mytrim_dynamic.C
+++ b/apps/mytrim_dynamic.C
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
   }
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   //Real A = 74.0, E = 1.0e5; int Z = 36; // 100keV Kr
   Real A = 131.0, E = 5.0e5; int Z = 54; // 500keV Xe
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
   snprintf(fname, 199, "%s.dist", argv[1]);
   FILE *rdist = fopen(fname, "wt");
 
-  ionBase *ff1, *pka;
+  IonBase *ff1, *pka;
   int nrec = 0;
   Real sum_r2 = 0.0;
   Point opos;
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
   {
     if (n % 100 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionBase;
+    ff1 = new IonBase;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->id = simconf->id++;
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
     ff1->pos(1) = sample->w[1] / 2.0;
     ff1->pos(2) = sample->w[2] / 2.0;
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
     while (!recoils.empty())

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
   std::cout << "n_layers=" << nlayer << std::endl;
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
   for (int i = 0; i < nlayer; i++)
   {
     std::cin >> lename >> lthick >> lrho >> nelem;
@@ -98,11 +98,11 @@ int main(int argc, char *argv[])
 
     for (int j = 0; j < nelem; j++)
     {
-      element = new elementBase;
-      std::cin >> lename >> element->z >> element->m >> element->t;
+      element = new ElementBase;
+      std::cin >> lename >> element->_Z >> element->_m >> element->_t;
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-      std::cout << "  Element: " << lename << "  Z=" << element->z
-           << "  m=" << element->m << "  fraction=" << element->t << std::endl;
+      std::cout << "  Element: " << lename << "  Z=" << element->_Z
+           << "  m=" << element->_m << "  fraction=" << element->_t << std::endl;
       material->element.push_back(element);
     }
 

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   std::cout << "n_layers=" << nlayer << std::endl;
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
   for (int i = 0; i < nlayer; i++)
   {
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
     std::cout << "Layer: " << lename << "  d=" << lthick << "Ang  rho="
          << lrho << "g/ccm  n_elements=" << nelem << std::endl;
 
-    material = new materialBase(simconf, lrho); // rho
+    material = new MaterialBase(simconf, lrho); // rho
 
     for (int j = 0; j < nelem; j++)
     {

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -74,8 +74,8 @@ int main(int argc, char *argv[])
   std::cout << "NN " << nmax << " PKAs" << std::endl;
 
   SampleLayers *sample = new SampleLayers(sx, sy, sz);
-  //trimBase *trim = new trimBase(sample);
-  trimBase *trim = new trimRecoils(simconf, sample);
+  //TrimBase *trim = new TrimBase(sample);
+  TrimBase *trim = new TrimRecoils(simconf, sample);
 
   // Read Materials description from stdin
   int nlayer;

--- a/apps/mytrim_layers.C
+++ b/apps/mytrim_layers.C
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
   const int nmax = 10000;
   std::cout << "NN " << nmax << " PKAs" << std::endl;
 
-  sampleLayers *sample = new sampleLayers(sx, sy, sz);
+  SampleLayers *sample = new SampleLayers(sx, sy, sz);
   //trimBase *trim = new trimBase(sample);
   trimBase *trim = new trimRecoils(simconf, sample);
 

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -63,10 +63,10 @@ int main(int, char **)
   sample->bc[1] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
   sample->bc[2] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
-  material = new materialBase(simconf, 1.0); // rho
+  material = new MaterialBase(simconf, 1.0); // rho
   element = new ElementBase;
   element->_Z = 20;
   element->_m = 40.0;

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -49,7 +49,7 @@ int main(int, char **)
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -55,13 +55,13 @@ int main(int, char **)
   //simconf->tmin = 0.2;
 
   // initialize sample structure
-  sampleSolid *sample = new sampleSolid(200.0, 200.0, 200.0);
+  SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
   trimBase *trim = new trimBase(simconf, sample);
 
-  sample->bc[0] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
-  sample->bc[1] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
-  sample->bc[2] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
+  sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
+  sample->bc[1] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
+  sample->bc[2] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
 
   MaterialBase *material;
   ElementBase *element;

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -57,7 +57,7 @@ int main(int, char **)
   // initialize sample structure
   SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
-  trimBase *trim = new trimBase(simconf, sample);
+  TrimBase *trim = new TrimBase(simconf, sample);
 
   sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
   sample->bc[1] = SampleBase::CUT; // no PBC in x (just clusterless matrix)

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -64,13 +64,13 @@ int main(int, char **)
   sample->bc[2] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   material = new materialBase(simconf, 1.0); // rho
-  element = new elementBase;
-  element->z = 20;
-  element->m = 40.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 20;
+  element->_m = 40.0;
+  element->_t = 1.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_moose_verification.C
+++ b/apps/mytrim_moose_verification.C
@@ -76,13 +76,13 @@ int main(int, char **)
   sample->material.push_back(material); // add material to sample
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   // create a bunch of ions
-  MyTRIM_NS::ionBase * pka;
+  MyTRIM_NS::IonBase * pka;
   for (unsigned int i = 0; i < 1000; ++i)
   {
-    pka = new MyTRIM_NS::ionBase;
+    pka = new MyTRIM_NS::IonBase;
     pka->gen = 0;  // generation (0 = PKA)
     pka->tag = 0; // tag holds the element type
     pka->_Z = 20;
@@ -97,7 +97,7 @@ int main(int, char **)
     pka->pos(1) = 0.01;
     pka->pos(2) = 100.0;
 
-    pka->set_ef();
+    pka->setEf();
     recoils.push(pka);
   }
 

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -66,11 +66,11 @@ int main(int argc, char *argv[])
 
   trimBase *trim = new trimBase(simconf, sample);
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   // UO2
-  material = new materialBase(simconf, 9.4); // rho
+  material = new MaterialBase(simconf, 9.4); // rho
   element = new ElementBase;
   element->_Z = 92; // U
   element->_m = 235.0;

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real norm;
   MassInverter *m = new MassInverter;
@@ -105,14 +105,14 @@ int main(int argc, char *argv[])
   snprintf(fname, 199, "%s.dist", argv[1]);
   FILE *rdist = fopen(fname, "wt");
 
-  ionMDtag *ff1, *pka;
+  IonMDTag *ff1, *pka;
 
   // 5 fission events
   for (int n = 0; n < 10; n++) // 10 ff
   {
     if (n % 100 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionMDtag;
+    ff1 = new IonMDTag;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->md = 0;
@@ -151,11 +151,11 @@ int main(int argc, char *argv[])
 
     for (int i = 0; i < 3; i++) ff1->pos(i) = dr250() * sample->w[i];
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
 /*
-    ff2 = new ionBase(*ff1); // copy constructor
+    ff2 = new IonBase(*ff1); // copy constructor
     //ff1->id = simconf->id++;
 
     // reverse direction
@@ -165,14 +165,14 @@ int main(int argc, char *argv[])
     ff2->_m = A2;
     ff2->e  = E2 * 1.0e6;
 
-    ff2->set_ef();
+    ff2->setEf();
     recoils.push(ff2);
 
     fprintf(stderr, "A1=%f Z1=%d (%f MeV)\tA2=%f Z2=%d (%f MeV)\n", A1, Z1, E1, A2, Z2, E2);
 */
     while (!recoils.empty())
     {
-      pka = dynamic_cast<ionMDtag*>(recoils.front());
+      pka = dynamic_cast<IonMDTag*>(recoils.front());
       recoils.pop();
       sample->averages(pka);
 

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
   // initialize sample structure
   SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
-  trimBase *trim = new trimBase(simconf, sample);
+  TrimBase *trim = new TrimBase(simconf, sample);
 
   MaterialBase *material;
   ElementBase *element;

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -67,24 +67,24 @@ int main(int argc, char *argv[])
   trimBase *trim = new trimBase(simconf, sample);
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   // UO2
   material = new materialBase(simconf, 9.4); // rho
-  element = new elementBase;
-  element->z = 92; // U
-  element->m = 235.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 92; // U
+  element->_m = 235.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 16; // O
-  element->m = 32.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 16; // O
+  element->_m = 32.0;
+  element->_t = 2.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 54; // Xe
-  element->m = 131.0;
-  element->t = 0.0024;
+  element = new ElementBase;
+  element->_Z = 54; // Xe
+  element->_m = 131.0;
+  element->_t = 0.0024;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_solid.C
+++ b/apps/mytrim_solid.C
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
   //simconf->tmin = 0.2;
 
   // initialize sample structure
-  sampleSolid *sample = new sampleSolid(200.0, 200.0, 200.0);
+  SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
   trimBase *trim = new trimBase(simconf, sample);
 

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -67,9 +67,9 @@ int main(int argc, char *argv[])
   // initialize trim engine for the sample
   snprintf(fname, 199, "%s.phon", argv[1]);
   //FILE *phon = fopen(fname, "wt");
-  //trimPhononOut *trim = new trimPhononOut(sample, phon);
-  //trimBase *trim = new trimBase(sample);
-  trimBase *trim = new trimPrimaries(simconf, sample);
+  //TrimPhononOut *trim = new TrimPhononOut(sample, phon);
+  //TrimBase *trim = new TrimBase(sample);
+  TrimBase *trim = new TrimPrimaries(simconf, sample);
 
   sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
 

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -77,12 +77,12 @@ int main(int argc, char *argv[])
   Real v_sam = sample->w[0] * sample->w[1] * sample->w[2];
   Real s_sam = sample->w[1] * sample->w[2];
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
 /*
   // Fe
-  material = new materialBase(simconf, 7.87); // rho
+  material = new MaterialBase(simconf, 7.87); // rho
   element = new ElementBase;
   element->_Z = 26; // Fe
   element->_m = 56.0;
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // ZrO2
-  material = new materialBase(simconf, 5.68); // rho
+  material = new MaterialBase(simconf, 5.68); // rho
   element = new ElementBase;
   element->_Z = 40; // Zr
   element->_m = 91.0;
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 */
 
   // ZrO2 Xe 0.01
-  material = new materialBase(simconf, 5.68); // rho
+  material = new MaterialBase(simconf, 5.68); // rho
   element = new ElementBase;
   element->_Z = 40; // Zr
   element->_m = 90.0;//91?
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
 
 /*
   // TiO2 precipitate
-  material = new materialBase(simconf, 4.23); // rho
+  material = new MaterialBase(simconf, 4.23); // rho
   element = new ElementBase;
   element->_Z = 22; // Ti
   element->_m = 48.0;
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
    // Y2Ti2O7 precipitate
-  material = new materialBase(simconf, 4.6); // rho between 4.23 and 5.01
+  material = new MaterialBase(simconf, 4.6); // rho between 4.23 and 5.01
   element = new ElementBase;
   element->_Z = 39; // Y
   element->_m = 89.0;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // xe bubble
-  material = new materialBase(simconf, 3.5); // rho
+  material = new MaterialBase(simconf, 3.5); // rho
   element = new ElementBase;
   element->_Z = 54; // Xe
   element->_m = 132.0;

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
   //simconf->tmin = 0.2;
 
   // initialize sample structure
-  sampleSolid *sample = new sampleSolid(200.0, 200.0, 200.0);
+  SampleSolid *sample = new SampleSolid(200.0, 200.0, 200.0);
 
   // initialize trim engine for the sample
   snprintf(fname, 199, "%s.phon", argv[1]);
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
   //trimBase *trim = new trimBase(sample);
   trimBase *trim = new trimPrimaries(simconf, sample);
 
-  sample->bc[0] = sampleBase::CUT; // no PBC in x (just clusterless matrix)
+  sample->bc[0] = SampleBase::CUT; // no PBC in x (just clusterless matrix)
 
   // Real atp = 0.1; // 10at% Mo 90at%Cu
   Real v_sam = sample->w[0] * sample->w[1] * sample->w[2];

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -182,7 +182,7 @@ int main(int argc, char *argv[])
 
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real dif2[3];
 
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
 
   Real pos2[3];
 
-  ionBase *ff1, *pka;
+  IonBase *ff1, *pka;
 
   //Real A = 84.0, E = 1.8e6; int Z = 36; // 1.8MeV Kr
   Real A = 131.0, E = 2.0e4; int Z = 54; // 20keV Xe
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
   {
     if (n % 10 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    ff1 = new ionBase;
+    ff1 = new IonBase;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->id = simconf->id++;
@@ -223,7 +223,7 @@ int main(int argc, char *argv[])
     ff1->pos(1) = sample->w[1] / 2.0;
     ff1->pos(2) = sample->w[2] / 2.0;
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
     while (!recoils.empty())

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -78,31 +78,31 @@ int main(int argc, char *argv[])
   Real s_sam = sample->w[1] * sample->w[2];
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
 /*
   // Fe
   material = new materialBase(simconf, 7.87); // rho
-  element = new elementBase;
-  element->z = 26; // Fe
-  element->m = 56.0;
-  element->t = 1.0;
-  element->Edisp = 40.0;
+  element = new ElementBase;
+  element->_Z = 26; // Fe
+  element->_m = 56.0;
+  element->_t = 1.0;
+  element->_Edisp = 40.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
 
   // ZrO2
   material = new materialBase(simconf, 5.68); // rho
-  element = new elementBase;
-  element->z = 40; // Zr
-  element->m = 91.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 40; // Zr
+  element->_m = 91.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
@@ -110,20 +110,20 @@ int main(int argc, char *argv[])
 
   // ZrO2 Xe 0.01
   material = new materialBase(simconf, 5.68); // rho
-  element = new elementBase;
-  element->z = 40; // Zr
-  element->m = 90.0;//91?
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 40; // Zr
+  element->_m = 90.0;//91?
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
-/*  element = new elementBase;
-  element->z = 54; // Xe
-  element->m = 132.0;
-  element->t = 0.01;
+/*  element = new ElementBase;
+  element->_Z = 54; // Xe
+  element->_m = 132.0;
+  element->_t = 0.01;
   material->element.push_back(element);*/
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
@@ -131,48 +131,48 @@ int main(int argc, char *argv[])
 /*
   // TiO2 precipitate
   material = new materialBase(simconf, 4.23); // rho
-  element = new elementBase;
-  element->z = 22; // Ti
-  element->m = 48.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 22; // Ti
+  element->_m = 48.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample
 
    // Y2Ti2O7 precipitate
   material = new materialBase(simconf, 4.6); // rho between 4.23 and 5.01
-  element = new elementBase;
-  element->z = 39; // Y
-  element->m = 89.0;
-  element->t = 2.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 39; // Y
+  element->_m = 89.0;
+  element->_t = 2.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 22; // Ti
-  element->m = 48.0;
-  element->t = 2.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 22; // Ti
+  element->_m = 48.0;
+  element->_t = 2.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 7.0;
-  element->Edisp = 57.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 7.0;
+  element->_Edisp = 57.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample
 
   // xe bubble
   material = new materialBase(simconf, 3.5); // rho
-  element = new elementBase;
-  element->z = 54; // Xe
-  element->m = 132.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 54; // Xe
+  element->_m = 132.0;
+  element->_t = 1.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_solid2.C
+++ b/apps/mytrim_solid2.C
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   simconf->fullTraj = false;
   simconf->tmin = 0.2;
   //simconf->tmin = 0.2;

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
   std::cout << "N_gas = " << N_gas << " (arho=" << material->arho << ")\n";
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
   Real norm;
   Real dif[3];
@@ -199,14 +199,14 @@ int main(int argc, char *argv[])
 
   Real pos1[3];
 
-  ionMDtag *ff1, *ff2, *pka;
+  IonMDTag *ff1, *ff2, *pka;
 
   // Nev fission events
   for (int n = 0; n < Nev; n++)
   {
     if (n % 10 == 0) std::cerr << "event #" << n+1 << "\n";
 
-    ff1 = new ionMDtag;
+    ff1 = new IonMDTag;
     ff1->gen = 0; // generation (0 = PKA)
     ff1->tag = -1;
     ff1->md = 0;
@@ -238,10 +238,10 @@ int main(int argc, char *argv[])
     // random origin
     for (int i = 0; i < 3; i++) ff1->pos(i) = dr250() * sample->w[i];
 
-    ff1->set_ef();
+    ff1->setEf();
     recoils.push(ff1);
 
-    ff2 = new ionMDtag(*ff1); // copy constructor
+    ff2 = new IonMDTag(*ff1); // copy constructor
 
     // reverse direction
     for (int i = 0; i < 3; i++) ff2->dir(i) *= -1.0;
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
     ff2->e  = E2 * 1.0e6;
     ff2->md = 0;
 
-    ff2->set_ef();
+    ff2->setEf();
     recoils.push(ff2);
 
     std::cout << "A1=" << A1 << " Z1=" << Z1 << " (" << E1 << " MeV)\t"
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 
     while (!recoils.empty())
     {
-      pka = dynamic_cast<ionMDtag*>(recoils.front());
+      pka = dynamic_cast<IonMDTag*>(recoils.front());
       recoils.pop();
       sample->averages(pka);
 

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed);
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
 
   // initialize sample structure
   sampleClusters *sample = new sampleClusters(400.0, 400.0, 400.0);

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
           {
             dif[i] =  sample->c[i][pka->tag] - pka->pos(i);
 
-            if (sample->bc[i] == sampleBase::PBC)
+            if (sample->bc[i] == SampleBase::PBC)
               dif[i] -= round(dif[i] / sample->w[i]) * sample->w[i];
 
             pos1[i] = pka->pos(i) + dif[i];

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -144,19 +144,19 @@ int main(int argc, char *argv[])
   std::cerr << "sample built.\n";
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   // UO2 TODO: Eidplacement and binding energies!
   material = new materialBase(simconf, 10.0); // rho
-  element = new elementBase;
-  element->z = 92; // U
-  element->m = 235.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 92; // U
+  element->_m = 235.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
@@ -165,10 +165,10 @@ int main(int argc, char *argv[])
   // xe bubble
   int gas_z1 = 54;
   material = new materialBase(simconf, 3.5); // rho
-  element = new elementBase;
-  element->z = gas_z1; // Xe
-  element->m = 132.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = gas_z1; // Xe
+  element->_m = 132.0;
+  element->_t = 1.0;
   material->element.push_back(element);
   material->prepare();
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -143,11 +143,11 @@ int main(int argc, char *argv[])
 
   std::cerr << "sample built.\n";
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   // UO2 TODO: Eidplacement and binding energies!
-  material = new materialBase(simconf, 10.0); // rho
+  material = new MaterialBase(simconf, 10.0); // rho
   element = new ElementBase;
   element->_Z = 92; // U
   element->_m = 235.0;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
 
   // xe bubble
   int gas_z1 = 54;
-  material = new materialBase(simconf, 3.5); // rho
+  material = new MaterialBase(simconf, 3.5); // rho
   element = new ElementBase;
   element->_Z = gas_z1; // Xe
   element->_m = 132.0;

--- a/apps/mytrim_uo2.C
+++ b/apps/mytrim_uo2.C
@@ -88,24 +88,24 @@ int main(int argc, char *argv[])
   sampleClusters *sample = new sampleClusters(400.0, 400.0, 400.0);
 
   // initialize trim engine for the sample
-  trimBase *trim;
+  TrimBase *trim;
   std::ofstream auxout;
   std::stringstream auxoutname;
   switch (mode) {
     case PLAIN:
-      trim = new trimBase(simconf, sample);
+      trim = new TrimBase(simconf, sample);
       break;
 
     case PHONONS:
       auxoutname << argv[1] << ".phonons";
       auxout.open(auxoutname.str().c_str());
-      trim = new trimPhononOut(simconf, sample, auxout);
+      trim = new TrimPhononOut(simconf, sample, auxout);
       break;
 
     case DEFECTS:
       auxoutname << argv[1] << ".defects";
       auxout.open(auxoutname.str().c_str());
-      trim = new trimDefectLog(simconf, sample, auxout);
+      trim = new TrimDefectLog(simconf, sample, auxout);
       break;
 
     default:

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -104,9 +104,9 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
-  ionBase *pka;
+  IonBase *pka;
 
   const int mx = 20, my = 20;
   int imap[mx][my][3];
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
   {
     if (n % 1000 == 0) fprintf(stderr, "pka #%d\n", n+1);
 
-    pka = new ionBase;
+    pka = new IonBase;
     pka->gen = 0; // generation (0 = PKA)
     pka->tag = -1;
     pka->_Z = zpka; // S
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     // wire surface
     pka->pos(1) = sample->w[1] / 2.0 * (1.0 + std::sqrt(1.0 - sqr((pka->pos(0) / sample->w[0]) * 2.0 - 1.0))) - 0.5;
 
-    pka->set_ef();
+    pka->setEf();
     recoils.push(pka);
 
     while (!recoils.empty())

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
   simconfType * simconf = new simconfType;
 
   // initialize sample structure
-  sampleWire *sample = new sampleWire(dwire, dwire, 100.0);
+  SampleWire *sample = new SampleWire(dwire, dwire, 100.0);
 
   // initialize trim engine for the sample
   const int z1 = 29; //Cu

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -81,10 +81,10 @@ int main(int argc, char *argv[])
   const int z3 = 47; //Ag
   trimVacMap *trim = new trimVacMap(simconf, sample, z1, z2, z3); // GaCW
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
-  material = new materialBase(simconf, (56.0*8.920 + 38.0*4.507 + 8.0*10.490)/(56.0+38.0+8.0)); // rho
+  material = new MaterialBase(simconf, (56.0*8.920 + 38.0*4.507 + 8.0*10.490)/(56.0+38.0+8.0)); // rho
   element = new ElementBase;
   element->_Z = z1; // Cu
   element->_m = 63.546;

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -82,23 +82,23 @@ int main(int argc, char *argv[])
   trimVacMap *trim = new trimVacMap(simconf, sample, z1, z2, z3); // GaCW
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   material = new materialBase(simconf, (56.0*8.920 + 38.0*4.507 + 8.0*10.490)/(56.0+38.0+8.0)); // rho
-  element = new elementBase;
-  element->z = z1; // Cu
-  element->m = 63.546;
-  element->t = 56.0;
+  element = new ElementBase;
+  element->_Z = z1; // Cu
+  element->_m = 63.546;
+  element->_t = 56.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = z2; // Ti
-  element->m = 47.867;
-  element->t = 38.0;
+  element = new ElementBase;
+  element->_Z = z2; // Ti
+  element->_m = 47.867;
+  element->_t = 38.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = z3; // Ag
-  element->m = 107.87;
-  element->t = 8.0;
+  element = new ElementBase;
+  element->_Z = z3; // Ag
+  element->_m = 107.87;
+  element->_t = 8.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
   const int z1 = 29; //Cu
   const int z2 = 22; //Ti
   const int z3 = 47; //Ag
-  trimVacMap *trim = new trimVacMap(simconf, sample, z1, z2, z3); // GaCW
+  TrimVacMap *trim = new TrimVacMap(simconf, sample, z1, z2, z3); // GaCW
 
   MaterialBase *material;
   ElementBase *element;

--- a/apps/mytrim_wire.C
+++ b/apps/mytrim_wire.C
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
 
   // initialize sample structure
   SampleWire *sample = new SampleWire(dwire, dwire, 100.0);

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -115,29 +115,29 @@ int main(int argc, char *argv[])
   trimBase *trim = new trimPrimaries(simconf, sample);
 
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
 
   // Si
   material = new materialBase(simconf, 2.329); // rho
-  element = new elementBase;
-  element->z = 14; // Si
-  element->m = 28.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 14; // Si
+  element->_m = 28.0;
+  element->_t = 1.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample
 
   // SiO2 (material[1] for the cover layer in SampleBurriedWire)
   material = new materialBase(simconf, 2.634); // rho
-  element = new elementBase;
-  element->z = 14; // Si
-  element->m = 28.0;
-  element->t = 1.0;
+  element = new ElementBase;
+  element->_Z = 14; // Si
+  element->_m = 28.0;
+  element->_t = 1.0;
   material->element.push_back(element);
-  element = new elementBase;
-  element->z = 8; // O
-  element->m = 16.0;
-  element->t = 2.0;
+  element = new ElementBase;
+  element->_Z = 8; // O
+  element->_m = 16.0;
+  element->_t = 2.0;
   material->element.push_back(element);
   material->prepare(); // all materials added
   sample->material.push_back(material); // add material to sample

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -63,12 +63,12 @@ int main(int argc, char *argv[])
   const int nstep = 5;
   Real ion_dose[nstep] = { 3.0e13, 2.2e13, 1.5e13, 1.2e13, 2.5e13 }; // in ions/cm^2
   int ion_count[nstep];
-  ionBase* ion_prototype[nstep];
-  ion_prototype[0] = new ionBase( 5, 11.0 , 320.0e3); // Z,m,E
-  ion_prototype[1] = new ionBase( 5, 11.0 , 220.0e3); // Z,m,E
-  ion_prototype[2] = new ionBase( 5, 11.0 , 160.0e3); // Z,m,E
-  ion_prototype[3] = new ionBase( 5, 11.0 , 120.0e3); // Z,m,E
-  ion_prototype[4] = new ionBase(15, 31.0 , 250.0e3); // Z,m,E
+  IonBase* ion_prototype[nstep];
+  ion_prototype[0] = new IonBase( 5, 11.0 , 320.0e3); // Z,m,E
+  ion_prototype[1] = new IonBase( 5, 11.0 , 220.0e3); // Z,m,E
+  ion_prototype[2] = new IonBase( 5, 11.0 , 160.0e3); // Z,m,E
+  ion_prototype[3] = new IonBase( 5, 11.0 , 120.0e3); // Z,m,E
+  ion_prototype[4] = new IonBase(15, 31.0 , 250.0e3); // Z,m,E
 
   // seed randomnumber generator from system entropy pool
   FILE *urand = fopen("/dev/random", "r");
@@ -143,9 +143,9 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // create a FIFO for recoils
-  std::queue<ionBase*> recoils;
+  std::queue<IonBase*> recoils;
 
-  ionBase *pka;
+  IonBase *pka;
 
   // map concentration along length
   int *lbins[2];
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
         std::cerr << "pka #" << n+1 << std::endl;
 
       // generate new PKA from prototype ion
-      pka = new ionBase(ion_prototype[s]);
+      pka = new IonBase(ion_prototype[s]);
       pka->gen = 0; // generation (0 = PKA)
       pka->tag = -1;
 
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
       //cout << "START " << pka->pos(0) << ' ' << pka->pos(1) << ' ' << pka->pos(2) << ' ' << std::endl;
       //continue;
 
-      pka->set_ef();
+      pka->setEf();
       recoils.push(pka);
 
       while (!recoils.empty())

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -114,11 +114,11 @@ int main(int argc, char *argv[])
   //trimBase *trim = new trimBase(sample);
   trimBase *trim = new trimPrimaries(simconf, sample);
 
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
 
   // Si
-  material = new materialBase(simconf, 2.329); // rho
+  material = new MaterialBase(simconf, 2.329); // rho
   element = new ElementBase;
   element->_Z = 14; // Si
   element->_m = 28.0;
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
   sample->material.push_back(material); // add material to sample
 
   // SiO2 (material[1] for the cover layer in SampleBurriedWire)
-  material = new materialBase(simconf, 2.634); // rho
+  material = new MaterialBase(simconf, 2.634); // rho
   element = new ElementBase;
   element->_Z = 14; // Si
   element->_m = 28.0;

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
   r250_init(seed<0 ? -seed : seed); // random generator goes haywire with neg. seed
 
   // initialize global parameter structure and read data tables from file
-  simconfType * simconf = new simconfType;
+  SimconfType * simconf = new SimconfType;
   //simconf->fullTraj = true;
 
   // initialize sample structure

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -109,10 +109,10 @@ int main(int argc, char *argv[])
   // initialize trim engine for the sample
   /*  const int z1 = 31;
       const int z2 = 33;
-      trimVacMap *trim = new trimVacMap(sample, z1, z2); // GaAs
+      TrimVacMap *trim = new TrimVacMap(sample, z1, z2); // GaAs
   */
-  //trimBase *trim = new trimBase(sample);
-  trimBase *trim = new trimPrimaries(simconf, sample);
+  //TrimBase *trim = new TrimBase(sample);
+  TrimBase *trim = new TrimPrimaries(simconf, sample);
 
   MaterialBase *material;
   ElementBase *element;

--- a/apps/mytrim_wire2.C
+++ b/apps/mytrim_wire2.C
@@ -82,13 +82,13 @@ int main(int argc, char *argv[])
   //simconf->fullTraj = true;
 
   // initialize sample structure
-  sampleWire *sample;
+  SampleWire *sample;
   if (burried)
-    sample = new sampleBurriedWire(diameter, diameter, length);
+    sample = new SampleBurriedWire(diameter, diameter, length);
   else
   {
-    sample = new sampleWire(diameter, diameter, length);
-    sample->bc[2] = sampleWire::CUT;
+    sample = new SampleWire(diameter, diameter, length);
+    sample->bc[2] = SampleWire::CUT;
   }
 
   // calculate actual ion numbers

--- a/element.C
+++ b/element.C
@@ -2,6 +2,6 @@
 
 using namespace MyTRIM_NS;
 
-elementBase::elementBase() : Edisp(25.0), Elbind(3.0)
+ElementBase::ElementBase() : _Edisp(25.0), _Elbind(3.0)
 {
 }

--- a/element.h
+++ b/element.h
@@ -5,16 +5,18 @@
 
 namespace MyTRIM_NS {
 
-struct elementBase {
-  int z;
-  Real m, t; // mass and relative amount
+class ElementBase
+{
+public:
+  ElementBase();
 
-  Real Edisp, Elbind; // displacement energy and lattice binding energy
+  int _Z;
+  Real _m, _t; // mass and relative amount
+
+  Real _Edisp, _Elbind; // displacement energy and lattice binding energy
 
   // calculated
   Real my, ec, ai, fi;
-
-  elementBase();
 };
 
 }

--- a/ion.C
+++ b/ion.C
@@ -4,14 +4,14 @@
 
 using namespace MyTRIM_NS;
 
-ionBase::ionBase() :
+IonBase::IonBase() :
     t(0.0),  // clock
     ef(3.0), // final energy
     state(MOVING)
 {
 }
 
-ionBase::ionBase(ionBase* prototype) :
+IonBase::IonBase(IonBase* prototype) :
     _Z(prototype->_Z),
     _m(prototype->_m),
     e(prototype->e),
@@ -21,7 +21,7 @@ ionBase::ionBase(ionBase* prototype) :
   t = prototype->t;   //clock
 }
 
-ionBase::ionBase(int Z, Real m, Real e_) :
+IonBase::IonBase(int Z, Real m, Real e_) :
     _Z(Z),
     _m(m),
     e(e_),
@@ -31,7 +31,8 @@ ionBase::ionBase(int Z, Real m, Real e_) :
   t = 0.0; //clock;
 }
 
-void ionBase::set_ef()
+void
+IonBase::setEf()
 {
   // stop following an ion if it's energy falls below 5.0eV
   ef = 3.0;
@@ -40,7 +41,8 @@ void ionBase::set_ef()
   //fmax(5.0, 0.00001 * e);
 }
 
-void ionBase::parent(ionBase *parent)
+void
+IonBase::parent(IonBase *parent)
 {
   ef = 3.0; // final energy
 
@@ -51,16 +53,17 @@ void ionBase::parent(ionBase *parent)
     pos(i) = parent->pos(i);
 }
 
-ionBase* ionBase::spawnRecoil()
+IonBase*
+IonBase::spawnRecoil()
 {
-  ionBase *recoil = new ionBase;
+  IonBase *recoil = new IonBase;
   recoil->parent(this);
   return recoil;
 }
 
 // output operator (implement for derived classes if necessary)
 namespace MyTRIM_NS {
-  std::ostream& operator << (std::ostream& os, const ionBase &i)
+  std::ostream& operator << (std::ostream& os, const IonBase &i)
   {
     os << i.pos(0) << ' ' << i.pos(1) << ' ' << i.pos(2) << ' '
        << i._Z << ' ' << i._m << ' ' << i.e << ' '
@@ -71,18 +74,19 @@ namespace MyTRIM_NS {
 }
 
 
-ionBase* ionMDtag::spawnRecoil()
+IonBase*
+IonMDTag::spawnRecoil()
 {
-  ionBase *recoil = new ionMDtag;
+  IonBase *recoil = new IonMDTag;
   recoil->parent(this);
   return recoil;
 }
 
 namespace MyTRIM_NS {
   // leverage the parent class output and augment it
-  std::ostream& operator << (std::ostream& os, const ionMDtag &i)
+  std::ostream& operator << (std::ostream& os, const IonMDTag &i)
   {
-    os << (static_cast<const ionBase &>(i)) <<  i.md << ' ';
+    os << (static_cast<const IonBase &>(i)) <<  i.md << ' ';
     return os;
   }
 }

--- a/ion.h
+++ b/ion.h
@@ -6,18 +6,18 @@
 
 namespace MyTRIM_NS {
 
-class ionBase
+class IonBase
 {
 public:
-  ionBase();
-  ionBase(ionBase* prototype);
-  ionBase(int Z, Real m, Real e_);
-  virtual ~ionBase() {};
+  IonBase();
+  IonBase(IonBase* prototype);
+  IonBase(int Z, Real m, Real e_);
+  virtual ~IonBase() {};
 
-  virtual void parent(ionBase* parent);
-  virtual ionBase* spawnRecoil();
+  virtual void parent(IonBase* parent);
+  virtual IonBase* spawnRecoil();
 
-  void set_ef();
+  void setEf();
 
   /// atomic number
   int _Z;
@@ -54,24 +54,24 @@ public:
 };
 
 /// Serialize ion into text stream
-std::ostream& operator << (std::ostream& os, const ionBase &i);
+std::ostream& operator << (std::ostream& os, const IonBase &i);
 
 
-class ionMDtag : public ionBase
+class IonMDTag : public IonBase
 {
 public:
-  ionMDtag() : ionBase(), md(0) {}
-  ionMDtag(ionMDtag * prototype) : ionBase(prototype), md(prototype->md) {}
+  IonMDTag() : IonBase(), md(0) {}
+  IonMDTag(IonMDTag * prototype) : IonBase(prototype), md(prototype->md) {}
 
-  /// overwrite this to return recoil ion objects of type ionMDtag
-  virtual ionBase* spawnRecoil();
+  /// overwrite this to return recoil ion objects of type IonMDTag
+  virtual IonBase* spawnRecoil();
 
   /// generation after first ion falling into the MD energy gap (200eV - 12000eV) TODO: move to subclass?
   int md;
 };
 
 /// Serialize ion into text stream
-std::ostream& operator << (std::ostream& os, const ionMDtag &p);
+std::ostream& operator << (std::ostream& os, const IonMDTag &p);
 }
 
 #endif

--- a/ion.h
+++ b/ion.h
@@ -45,8 +45,8 @@ public:
 
   // state of the recoil:
   //   MOVING          ion is still being tracked
-  //   REPLACEMENT     pka->_Z == element->z && pka->e < element->Edisp
-  //   SUBSTITUTIONAL  pka->_Z != element->z && pka->e < element->Edisp
+  //   REPLACEMENT     pka->_Z == element->_Z && pka->e < element->_Edisp
+  //   SUBSTITUTIONAL  pka->_Z != element->_Z && pka->e < element->_Edisp
   //   INTERSTITIAL    no recoil spawned and pke->e < pka->ef
   //   LOST            ion has left the sample
   enum StateType { MOVING, REPLACEMENT, SUBSTITUTIONAL, INTERSTITIAL, LOST } state;

--- a/material.C
+++ b/material.C
@@ -45,7 +45,7 @@ void materialBase::prepare()
 }
 
 // make sure layers are prepare'd first!
-void materialBase::average(const ionBase * pka)
+void materialBase::average(const IonBase * pka)
 {
   mu = pka->_m / am;
 
@@ -76,7 +76,7 @@ void materialBase::average(const ionBase * pka)
 }
 
 // make sure layers are prepare'd and averaged first!
-Real materialBase::getrstop(const ionBase * pka)
+Real materialBase::getrstop(const IonBase * pka)
 {
   Real se = 0.0;
   for (unsigned int i = 0; i < element.size(); ++i)
@@ -111,7 +111,7 @@ Real materialBase::rpstop(int z2p, Real e)
   return sp;
 }
 
-Real materialBase::rstop(const ionBase * ion, int z2)
+Real materialBase::rstop(const IonBase * ion, int z2)
 {
   Real e, vrmin, yrmin, v, vr, yr, vmin, m1;
   Real a, b, q, q1, l, l0, l1;

--- a/material.C
+++ b/material.C
@@ -8,7 +8,7 @@
 
 using namespace MyTRIM_NS;
 
-materialBase::materialBase(simconfType * simconf_, Real rho_) :
+MaterialBase::MaterialBase(simconfType * simconf_, Real rho_) :
     rho(rho_),
     tag(-1),
     dirty(true),
@@ -16,7 +16,8 @@ materialBase::materialBase(simconfType * simconf_, Real rho_) :
 {
 }
 
-void materialBase::prepare()
+void
+MaterialBase::prepare()
 {
   Real tt = 0.0;
 
@@ -45,7 +46,8 @@ void materialBase::prepare()
 }
 
 // make sure layers are prepare'd first!
-void materialBase::average(const IonBase * pka)
+void
+MaterialBase::average(const IonBase * pka)
 {
   mu = pka->_m / am;
 
@@ -76,7 +78,8 @@ void materialBase::average(const IonBase * pka)
 }
 
 // make sure layers are prepare'd and averaged first!
-Real materialBase::getrstop(const IonBase * pka)
+Real
+MaterialBase::getrstop(const IonBase * pka)
 {
   Real se = 0.0;
   for (unsigned int i = 0; i < element.size(); ++i)
@@ -85,7 +88,8 @@ Real materialBase::getrstop(const IonBase * pka)
   return se;
 }
 
-Real materialBase::rpstop(int z2p, Real e)
+Real
+MaterialBase::rpstop(int z2p, Real e)
 {
   Real pe, pe0, sl, sh, sp, velpwr;
   int z2 = z2p-1;
@@ -111,7 +115,8 @@ Real materialBase::rpstop(int z2p, Real e)
   return sp;
 }
 
-Real materialBase::rstop(const IonBase * ion, int z2)
+Real
+MaterialBase::rstop(const IonBase * ion, int z2)
 {
   Real e, vrmin, yrmin, v, vr, yr, vmin, m1;
   Real a, b, q, q1, l, l0, l1;

--- a/material.C
+++ b/material.C
@@ -23,22 +23,22 @@ void materialBase::prepare()
   // get total stoichiometry
   for (unsigned int i = 0; i < element.size(); ++i)
   {
-    if (element[i]->t < 0.0)
-      element[i]->t = 0.0;
-    tt += element[i]->t;
+    if (element[i]->_t < 0.0)
+      element[i]->_t = 0.0;
+    tt += element[i]->_t;
   }
 
   // normalize relative probabilities to 1
   for (unsigned int i = 0; i < element.size(); ++i)
-    element[i]->t /= tt;
+    element[i]->_t /= tt;
 
   // average
   am = 0.0;
   az = 0.0;
   for (unsigned int i = 0; i < element.size(); ++i)
   {
-    am += element[i]->m * element[i]->t;
-    az += Real(element[i]->z) * element[i]->t;
+    am += element[i]->_m * element[i]->_t;
+    az += Real(element[i]->_Z) * element[i]->_t;
   }
 
   arho = rho * 0.6022 / am; //[TRI00310] atoms/Ang^3
@@ -64,12 +64,12 @@ void materialBase::average(const ionBase * pka)
 
   for (unsigned int i = 0; i < element.size(); ++i)
   {
-    element[i]->my = pka->_m / element[i]->m;
+    element[i]->my = pka->_m / element[i]->_m;
     element[i]->ec = 4.0 * element[i]->my / std::pow(1.0 + element[i]->my, 2.0);
-    element[i]->ai = .5292 * .8853 / (std::pow(Real(pka->_Z), 0.23) + std::pow(element[i]->z, 0.23));
+    element[i]->ai = .5292 * .8853 / (std::pow(Real(pka->_Z), 0.23) + std::pow(element[i]->_Z, 0.23));
     //ai = .5292 * .8853 / std::pow(pow(Real(pka._Z), 0.5) + std::pow(element[i].z, 0.5), 2.0/3.0);
-    element[i]->fi = element[i]->ai * element[i]->m /
-                     (Real(pka->_Z) * Real(element[i]->z) * 14.4 * (pka->_m + element[i]->m));
+    element[i]->fi = element[i]->ai * element[i]->_m /
+                     (Real(pka->_Z) * Real(element[i]->_Z) * 14.4 * (pka->_m + element[i]->_m));
   }
 
   dirty = false;
@@ -80,7 +80,7 @@ Real materialBase::getrstop(const ionBase * pka)
 {
   Real se = 0.0;
   for (unsigned int i = 0; i < element.size(); ++i)
-    se += rstop(pka, element[i]->z) * element[i]->t * arho;
+    se += rstop(pka, element[i]->_Z) * element[i]->_t * arho;
 
   return se;
 }

--- a/material.C
+++ b/material.C
@@ -8,7 +8,7 @@
 
 using namespace MyTRIM_NS;
 
-MaterialBase::MaterialBase(simconfType * simconf_, Real rho_) :
+MaterialBase::MaterialBase(SimconfType * simconf_, Real rho_) :
     rho(rho_),
     tag(-1),
     dirty(true),

--- a/material.h
+++ b/material.h
@@ -47,7 +47,7 @@ struct materialBase {
   int tag;
   bool dirty;
 
-  std::vector<elementBase*> element;
+  std::vector<ElementBase*> element;
 
   materialBase(simconfType * simconf_, Real rho_);
 
@@ -58,7 +58,7 @@ struct materialBase {
   void average(const ionBase *pka);
   Real getrstop(const ionBase *pka);
 
-  virtual elementBase * getElement(unsigned int nn) { return element[nn]; }
+  virtual ElementBase * getElement(unsigned int nn) { return element[nn]; }
 
 protected:
   Real rpstop(int z2, Real e);

--- a/material.h
+++ b/material.h
@@ -55,14 +55,14 @@ struct materialBase {
   void prepare();
 
   // compute pka dependent averages
-  void average(const ionBase *pka);
-  Real getrstop(const ionBase *pka);
+  void average(const IonBase *pka);
+  Real getrstop(const IonBase *pka);
 
   virtual ElementBase * getElement(unsigned int nn) { return element[nn]; }
 
 protected:
   Real rpstop(int z2, Real e);
-  Real rstop(const ionBase *ion, int z2);
+  Real rstop(const IonBase *ion, int z2);
 
   simconfType * simconf;
 };

--- a/material.h
+++ b/material.h
@@ -30,7 +30,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct materialBase {
+class MaterialBase {
+public:
+  MaterialBase(simconfType * simconf_, Real rho_);
+
+  // make sure stoiciometry is normalized, compute averages independent of pka
+  void prepare();
+
+  // compute pka dependent averages
+  void average(const IonBase *pka);
+  Real getrstop(const IonBase *pka);
+
+  virtual ElementBase * getElement(unsigned int nn) { return element[nn]; }
+
   Real rho;
 
   // set in prepare
@@ -48,17 +60,6 @@ struct materialBase {
   bool dirty;
 
   std::vector<ElementBase*> element;
-
-  materialBase(simconfType * simconf_, Real rho_);
-
-  // make sure stoiciometry is normalized, compute averages independent of pka
-  void prepare();
-
-  // compute pka dependent averages
-  void average(const IonBase *pka);
-  Real getrstop(const IonBase *pka);
-
-  virtual ElementBase * getElement(unsigned int nn) { return element[nn]; }
 
 protected:
   Real rpstop(int z2, Real e);

--- a/material.h
+++ b/material.h
@@ -30,7 +30,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-class MaterialBase {
+class MaterialBase
+{
 public:
   MaterialBase(simconfType * simconf_, Real rho_);
 

--- a/material.h
+++ b/material.h
@@ -33,7 +33,7 @@ namespace MyTRIM_NS {
 class MaterialBase
 {
 public:
-  MaterialBase(simconfType * simconf_, Real rho_);
+  MaterialBase(SimconfType * simconf_, Real rho_);
 
   // make sure stoiciometry is normalized, compute averages independent of pka
   void prepare();
@@ -66,7 +66,7 @@ protected:
   Real rpstop(int z2, Real e);
   Real rstop(const IonBase *ion, int z2);
 
-  simconfType * simconf;
+  SimconfType * simconf;
 };
 
 }

--- a/sample.C
+++ b/sample.C
@@ -9,7 +9,7 @@ sampleBase::sampleBase(Real x, Real y, Real z)
     bc[i] = PBC;
 }
 
-void sampleBase::averages(const ionBase * pka)
+void sampleBase::averages(const IonBase * pka)
 {
   for (unsigned int i = 0; i < material.size(); ++i)
     material[i]->average(pka);

--- a/sample.C
+++ b/sample.C
@@ -2,14 +2,15 @@
 
 using namespace MyTRIM_NS;
 
-sampleBase::sampleBase(Real x, Real y, Real z)
+SampleBase::SampleBase(Real x, Real y, Real z)
 {
   w[0] = x; w[1] = y; w[2] = z;
   for (unsigned int i = 0; i < 3; ++i)
     bc[i] = PBC;
 }
 
-void sampleBase::averages(const IonBase * pka)
+void
+SampleBase::averages(const IonBase * pka)
 {
   for (unsigned int i = 0; i < material.size(); ++i)
     material[i]->average(pka);

--- a/sample.h
+++ b/sample.h
@@ -29,18 +29,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleBase {
-  enum sampleBoundary { PBC, INF, CUT }; // periodic, infinitly large, cut off cascades
-
-  std::vector<MaterialBase*> material;
-  Real w[3]; // simulation volume
-  sampleBoundary bc[3]; // boundary conditions
+class SampleBase
+{
+public:
+  SampleBase(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
   virtual void averages(const IonBase  * pka);
   virtual MaterialBase* lookupMaterial(Point & pos) = 0;
   virtual Real rangeMaterial(Point & /* pos */, Point & /* dir */) { return 100000.0; };
 
-  sampleBase(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
+  /// materials in the sample
+  std::vector<MaterialBase*> material;
+
+  /// simulation volume
+  Real w[3];
+
+  /// periodic, infinitly large, cut off cascades
+  enum sampleBoundary { PBC, INF, CUT };
+
+  /// boundary conditions
+  sampleBoundary bc[3];
 };
 
 }

--- a/sample.h
+++ b/sample.h
@@ -36,7 +36,7 @@ struct sampleBase {
   Real w[3]; // simulation volume
   sampleBoundary bc[3]; // boundary conditions
 
-  virtual void averages(const ionBase  * pka);
+  virtual void averages(const IonBase  * pka);
   virtual materialBase* lookupMaterial(Point & pos) = 0;
   virtual Real rangeMaterial(Point & /* pos */, Point & /* dir */) { return 100000.0; };
 

--- a/sample.h
+++ b/sample.h
@@ -32,12 +32,12 @@ namespace MyTRIM_NS {
 struct sampleBase {
   enum sampleBoundary { PBC, INF, CUT }; // periodic, infinitly large, cut off cascades
 
-  std::vector<materialBase*> material;
+  std::vector<MaterialBase*> material;
   Real w[3]; // simulation volume
   sampleBoundary bc[3]; // boundary conditions
 
   virtual void averages(const IonBase  * pka);
-  virtual materialBase* lookupMaterial(Point & pos) = 0;
+  virtual MaterialBase* lookupMaterial(Point & pos) = 0;
   virtual Real rangeMaterial(Point & /* pos */, Point & /* dir */) { return 100000.0; };
 
   sampleBase(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);

--- a/sample_burried_wire.C
+++ b/sample_burried_wire.C
@@ -15,7 +15,7 @@ sampleBurriedWire::sampleBurriedWire(Real x, Real y, Real z)  : sampleWire(x, y,
 }
 
 // look if we are within dr of the wire axis
-materialBase* sampleBurriedWire::lookupMaterial(Point & pos)
+MaterialBase* sampleBurriedWire::lookupMaterial(Point & pos)
 {
   // cover layer
   if (pos(2) < 0.0 && pos(2) >= -250.0)
@@ -26,7 +26,7 @@ materialBase* sampleBurriedWire::lookupMaterial(Point & pos)
     return 0;
 
   // in wire layer
-  materialBase *ret = sampleWire::lookupMaterial(pos);
+  MaterialBase *ret = sampleWire::lookupMaterial(pos);
   if (ret == 0)
     return material[1];
   else

--- a/sample_burried_wire.C
+++ b/sample_burried_wire.C
@@ -7,7 +7,8 @@
 
 using namespace MyTRIM_NS;
 
-sampleBurriedWire::sampleBurriedWire(Real x, Real y, Real z)  : sampleWire(x, y, z)
+SampleBurriedWire::SampleBurriedWire(Real x, Real y, Real z) :
+    SampleWire(x, y, z)
 {
  bc[0] = INF;
  bc[1] = INF;
@@ -15,7 +16,8 @@ sampleBurriedWire::sampleBurriedWire(Real x, Real y, Real z)  : sampleWire(x, y,
 }
 
 // look if we are within dr of the wire axis
-MaterialBase* sampleBurriedWire::lookupMaterial(Point & pos)
+MaterialBase*
+SampleBurriedWire::lookupMaterial(Point & pos)
 {
   // cover layer
   if (pos(2) < 0.0 && pos(2) >= -250.0)
@@ -26,7 +28,7 @@ MaterialBase* sampleBurriedWire::lookupMaterial(Point & pos)
     return 0;
 
   // in wire layer
-  MaterialBase *ret = sampleWire::lookupMaterial(pos);
+  MaterialBase *ret = SampleWire::lookupMaterial(pos);
   if (ret == 0)
     return material[1];
   else

--- a/sample_burried_wire.h
+++ b/sample_burried_wire.h
@@ -28,7 +28,7 @@ namespace MyTRIM_NS {
 struct sampleBurriedWire : sampleWire {
   sampleBurriedWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
 };
 
 }

--- a/sample_burried_wire.h
+++ b/sample_burried_wire.h
@@ -25,8 +25,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleBurriedWire : sampleWire {
-  sampleBurriedWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
+class SampleBurriedWire : public SampleWire
+{
+public:
+  SampleBurriedWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
   virtual MaterialBase* lookupMaterial(Point & pos);
 };

--- a/sample_clusters.C
+++ b/sample_clusters.C
@@ -18,7 +18,7 @@ sampleClusters::sampleClusters(Real x, Real y, Real z) :
 
 // look if we are within dr of a cluster
 // dr == 0.0 means looking if we are inside the cluster
-materialBase* sampleClusters::lookupMaterial(Point & pos)
+MaterialBase* sampleClusters::lookupMaterial(Point & pos)
 {
   int l = lookupCluster(pos, 0.0);
 

--- a/sample_clusters.C
+++ b/sample_clusters.C
@@ -9,7 +9,7 @@
 using namespace MyTRIM_NS;
 
 sampleClusters::sampleClusters(Real x, Real y, Real z) :
-    sampleBase(x, y, z)
+    SampleBase(x, y, z)
 {
   sh = 0;
   cl = 0; cn = 0; cnm = 0;

--- a/sample_clusters.h
+++ b/sample_clusters.h
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleClusters : sampleBase {
+struct sampleClusters : SampleBase {
 
   Real sd, kd[3]; // half the spatial diagonal of a hash block, hash block size
   int *sh, kn[3]; // spatial hash and its dimensions

--- a/sample_clusters.h
+++ b/sample_clusters.h
@@ -36,7 +36,7 @@ struct sampleClusters : sampleBase {
 
   sampleClusters(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
 
   int lookupCluster(Point & pos, Real dr = 0.0);
   void initSpatialhash(int x, int y, int z);

--- a/sample_dynamic.C
+++ b/sample_dynamic.C
@@ -6,7 +6,7 @@
 
 using namespace MyTRIM_NS;
 
-SampleDynamic::SampleDynamic(simconfType * simconf_, Real x, Real y, Real z):
+SampleDynamic::SampleDynamic(SimconfType * simconf_, Real x, Real y, Real z):
     SampleLayers(x, y, z),
     simconf(simconf_)
 {

--- a/sample_dynamic.C
+++ b/sample_dynamic.C
@@ -15,7 +15,7 @@ sampleDynamic::sampleDynamic(simconfType * simconf_, Real x, Real y, Real z):
   bc[2] = PBC;
 }
 
-void sampleDynamic::averages(const ionBase *_pka)
+void sampleDynamic::averages(const IonBase *_pka)
 {
   // remember pka, we do not calculate averages right now, but on demand!
   pka = _pka;

--- a/sample_dynamic.C
+++ b/sample_dynamic.C
@@ -25,10 +25,10 @@ void sampleDynamic::averages(const IonBase *_pka)
   while (i > 0) material[--i]->dirty = true;
 }
 
-materialBase*  sampleDynamic::lookupMaterial(Point & pos)
+MaterialBase*  sampleDynamic::lookupMaterial(Point & pos)
 {
   //std::cout << "lookuplayer" << std::endl;
-  materialBase* m = material[lookupLayer(pos)];
+  MaterialBase* m = material[lookupLayer(pos)];
   //std::cout << m << ' ' << m->arho << ' ' << m->am << ' ' << m->az << ' ' << m->mu << std::endl;
 
   // on-demand update

--- a/sample_dynamic.C
+++ b/sample_dynamic.C
@@ -6,8 +6,8 @@
 
 using namespace MyTRIM_NS;
 
-sampleDynamic::sampleDynamic(simconfType * simconf_, Real x, Real y, Real z):
-    sampleLayers(x, y, z),
+SampleDynamic::SampleDynamic(simconfType * simconf_, Real x, Real y, Real z):
+    SampleLayers(x, y, z),
     simconf(simconf_)
 {
   bc[0] = CUT;
@@ -15,7 +15,8 @@ sampleDynamic::sampleDynamic(simconfType * simconf_, Real x, Real y, Real z):
   bc[2] = PBC;
 }
 
-void sampleDynamic::averages(const IonBase *_pka)
+void
+SampleDynamic::averages(const IonBase *_pka)
 {
   // remember pka, we do not calculate averages right now, but on demand!
   pka = _pka;
@@ -25,7 +26,8 @@ void sampleDynamic::averages(const IonBase *_pka)
   while (i > 0) material[--i]->dirty = true;
 }
 
-MaterialBase*  sampleDynamic::lookupMaterial(Point & pos)
+MaterialBase*
+SampleDynamic::lookupMaterial(Point & pos)
 {
   //std::cout << "lookuplayer" << std::endl;
   MaterialBase* m = material[lookupLayer(pos)];
@@ -41,7 +43,8 @@ MaterialBase*  sampleDynamic::lookupMaterial(Point & pos)
   return m;
 }
 
-void sampleDynamic::addAtomsToLayer(int layer, int n, int Z)
+void
+SampleDynamic::addAtomsToLayer(int layer, int n, int Z)
 {
   unsigned int i, ne = material[layer]->element.size();
   Real rnorm = 0.0; // volume of one atom with the fractional composition of the layer at natural density

--- a/sample_dynamic.C
+++ b/sample_dynamic.C
@@ -49,17 +49,17 @@ void sampleDynamic::addAtomsToLayer(int layer, int n, int Z)
   // look which element in the layer we are modifying and take weighted average of 1/rho of elements
   for (i = 0; i < material[layer]->element.size(); ++i)
   {
-    if (material[layer]->element[i]->z == Z) ne = i;
-    rnorm += material[layer]->element[i]->t / simconf->scoef[material[layer]->element[i]->z-1].atrho;
+    if (material[layer]->element[i]->_Z == Z) ne = i;
+    rnorm += material[layer]->element[i]->_t / simconf->scoef[material[layer]->element[i]->_Z-1].atrho;
   }
 
   // element not yet contained in layer
   if (ne == material[layer]->element.size())
   {
-    elementBase* element = new elementBase;
-    element->z = Z;
-    element->m = simconf->scoef[Z-1].m1;
-    element->t = 0.0;
+    ElementBase* element = new ElementBase;
+    element->_Z = Z;
+    element->_m = simconf->scoef[Z-1].m1;
+    element->_t = 0.0;
     material[layer]->element.push_back(element);
   }
 
@@ -70,19 +70,19 @@ void sampleDynamic::addAtomsToLayer(int layer, int n, int Z)
   int nl    = material[layer]->arho * w[1] * w[2] * layerThickness[layer];
 
   // mass change of layer (g/mole = g/(0.6022*10^24))
-  Real ma = 0.6022 * material[layer]->element[ne]->m * Real(n);
+  Real ma = 0.6022 * material[layer]->element[ne]->_m * Real(n);
 
   // keep density consistent...
   layerThickness[layer] += ma / (material[layer]->rho * w[1] * w[2]);
 
   // change stoichiometry (arho 1/ang^3 * ang^3)
-  if (material[layer]->element[ne]->t*nl + Real(n) < 0.0)
+  if (material[layer]->element[ne]->_t*nl + Real(n) < 0.0)
   {
-    std::cout << "Crap, t*nl=" << material[layer]->element[ne]->t*nl << ", but n=" << n << std::endl;
-    material[layer]->element[ne]->t = 0.0;
+    std::cout << "Crap, t*nl=" << material[layer]->element[ne]->_t*nl << ", but n=" << n << std::endl;
+    material[layer]->element[ne]->_t = 0.0;
   }
   else
-    material[layer]->element[ne]->t += Real(n)/nl; // sum t will be scaled to 1.0 in material->prepare()
+    material[layer]->element[ne]->_t += Real(n)/nl; // sum t will be scaled to 1.0 in material->prepare()
 
   // mark as dirty, just in case, and re-prepare to update averages
   material[layer]->dirty = true;

--- a/sample_dynamic.h
+++ b/sample_dynamic.h
@@ -31,7 +31,7 @@ namespace MyTRIM_NS {
 class SampleDynamic : public SampleLayers
 {
 public:
-  SampleDynamic(simconfType * _simconf, Real x, Real y, Real z);
+  SampleDynamic(SimconfType * _simconf, Real x, Real y, Real z);
 
   virtual void averages(const IonBase *_pka);
   virtual MaterialBase* lookupMaterial(Point & pos);
@@ -41,7 +41,7 @@ public:
 protected:
   const IonBase *pka;
 
-  simconfType * simconf;
+  SimconfType * simconf;
 };
 
 }

--- a/sample_dynamic.h
+++ b/sample_dynamic.h
@@ -29,9 +29,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 namespace MyTRIM_NS {
 
 struct sampleDynamic : sampleLayers {
-  const ionBase *pka;
+  const IonBase *pka;
 
-  virtual void averages(const ionBase *_pka);
+  virtual void averages(const IonBase *_pka);
 
   sampleDynamic(simconfType * _simconf, Real x, Real y, Real z);
 

--- a/sample_dynamic.h
+++ b/sample_dynamic.h
@@ -28,17 +28,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleDynamic : sampleLayers {
-  const IonBase *pka;
+class SampleDynamic : public SampleLayers
+{
+public:
+  SampleDynamic(simconfType * _simconf, Real x, Real y, Real z);
 
   virtual void averages(const IonBase *_pka);
-
-  sampleDynamic(simconfType * _simconf, Real x, Real y, Real z);
-
   virtual MaterialBase* lookupMaterial(Point & pos);
+
   virtual void addAtomsToLayer(int layer, int n, int Z);
 
 protected:
+  const IonBase *pka;
+
   simconfType * simconf;
 };
 

--- a/sample_dynamic.h
+++ b/sample_dynamic.h
@@ -35,7 +35,7 @@ struct sampleDynamic : sampleLayers {
 
   sampleDynamic(simconfType * _simconf, Real x, Real y, Real z);
 
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
   virtual void addAtomsToLayer(int layer, int n, int Z);
 
 protected:

--- a/sample_layers.C
+++ b/sample_layers.C
@@ -20,7 +20,7 @@ int sampleLayers::lookupLayer(Point & pos)
   return i;
 }
 
-materialBase*  sampleLayers::lookupMaterial(Point & pos)
+MaterialBase*  sampleLayers::lookupMaterial(Point & pos)
 {
   return material[lookupLayer(pos)];
 }

--- a/sample_layers.C
+++ b/sample_layers.C
@@ -3,7 +3,8 @@
 
 using namespace MyTRIM_NS;
 
-int sampleLayers::lookupLayer(Point & pos)
+int
+SampleLayers::lookupLayer(Point & pos)
 {
   unsigned int i;
   Real d = 0.0;
@@ -20,13 +21,15 @@ int sampleLayers::lookupLayer(Point & pos)
   return i;
 }
 
-MaterialBase*  sampleLayers::lookupMaterial(Point & pos)
+MaterialBase*
+SampleLayers::lookupMaterial(Point & pos)
 {
   return material[lookupLayer(pos)];
 }
 
 
-Real sampleLayers::rangeMaterial(Point & pos, Point & dir)
+Real
+SampleLayers::rangeMaterial(Point & pos, Point & dir)
 {
   // assume dir is a normalized vector
   Real d = 0.0;

--- a/sample_layers.h
+++ b/sample_layers.h
@@ -26,13 +26,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleLayers : sampleBase {
-  std::vector<Real> layerThickness;
+class SampleLayers : public SampleBase
+{
+public:
+  SampleLayers(Real x, Real y, Real z): SampleBase(x, y, z) {};
 
-  sampleLayers(Real x, Real y, Real z): sampleBase(x, y, z) {};
-  virtual int lookupLayer(Point & pos);
   virtual MaterialBase* lookupMaterial(Point & pos);
   virtual Real rangeMaterial(Point & pos, Point & dir);
+
+  virtual int lookupLayer(Point & pos);
+  std::vector<Real> layerThickness;
 };
 
 }

--- a/sample_layers.h
+++ b/sample_layers.h
@@ -31,7 +31,7 @@ struct sampleLayers : sampleBase {
 
   sampleLayers(Real x, Real y, Real z): sampleBase(x, y, z) {};
   virtual int lookupLayer(Point & pos);
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
   virtual Real rangeMaterial(Point & pos, Point & dir);
 };
 

--- a/sample_solid.C
+++ b/sample_solid.C
@@ -2,7 +2,7 @@
 
 using namespace MyTRIM_NS;
 
-materialBase*  sampleSolid::lookupMaterial(Point & /* pos */)
+MaterialBase*  sampleSolid::lookupMaterial(Point & /* pos */)
 {
   return material[0];
 }

--- a/sample_solid.C
+++ b/sample_solid.C
@@ -2,7 +2,8 @@
 
 using namespace MyTRIM_NS;
 
-MaterialBase*  sampleSolid::lookupMaterial(Point & /* pos */)
+MaterialBase*
+SampleSolid::lookupMaterial(Point & /* pos */)
 {
   return material[0];
 }

--- a/sample_solid.h
+++ b/sample_solid.h
@@ -27,7 +27,7 @@ namespace MyTRIM_NS {
 
 struct sampleSolid : sampleBase {
   sampleSolid(Real x, Real y, Real z): sampleBase(x, y, z) {};
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
 };
 
 }

--- a/sample_solid.h
+++ b/sample_solid.h
@@ -25,8 +25,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleSolid : sampleBase {
-  sampleSolid(Real x, Real y, Real z): sampleBase(x, y, z) {};
+struct SampleSolid : public SampleBase
+{
+public:
+  SampleSolid(Real x, Real y, Real z) : SampleBase(x, y, z) {};
+
   virtual MaterialBase* lookupMaterial(Point & pos);
 };
 

--- a/sample_wire.C
+++ b/sample_wire.C
@@ -7,14 +7,16 @@
 
 using namespace MyTRIM_NS;
 
-sampleWire::sampleWire(Real x, Real y, Real z)  : sampleBase(x, y, z)
+SampleWire::SampleWire(Real x, Real y, Real z) :
+    SampleBase(x, y, z)
 {
- bc[0] = CUT;
- bc[1] = CUT;
+  bc[0] = CUT;
+  bc[1] = CUT;
 }
 
 // look if we are within dr of the wire axis
-MaterialBase* sampleWire::lookupMaterial(Point & pos)
+MaterialBase*
+SampleWire::lookupMaterial(Point & pos)
 {
   Real x = (pos(0) / w[0]) * 2.0 - 1.0;
   Real y = (pos(1) / w[1]) * 2.0 - 1.0;

--- a/sample_wire.C
+++ b/sample_wire.C
@@ -14,7 +14,7 @@ sampleWire::sampleWire(Real x, Real y, Real z)  : sampleBase(x, y, z)
 }
 
 // look if we are within dr of the wire axis
-materialBase* sampleWire::lookupMaterial(Point & pos)
+MaterialBase* sampleWire::lookupMaterial(Point & pos)
 {
   Real x = (pos(0) / w[0]) * 2.0 - 1.0;
   Real y = (pos(1) / w[1]) * 2.0 - 1.0;

--- a/sample_wire.h
+++ b/sample_wire.h
@@ -25,8 +25,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 namespace MyTRIM_NS {
 
-struct sampleWire : sampleBase {
-  sampleWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
+class SampleWire : public SampleBase
+{
+public:
+  SampleWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
   virtual MaterialBase* lookupMaterial(Point & pos);
 };

--- a/sample_wire.h
+++ b/sample_wire.h
@@ -28,7 +28,7 @@ namespace MyTRIM_NS {
 struct sampleWire : sampleBase {
   sampleWire(Real x = 10000.0, Real y = 10000.0, Real z = 10000.0);
 
-  virtual materialBase* lookupMaterial(Point & pos);
+  virtual MaterialBase* lookupMaterial(Point & pos);
 };
 
 }

--- a/simconf.C
+++ b/simconf.C
@@ -11,12 +11,12 @@
 #include "simconf.h"
 
 namespace MyTRIM_NS {
-  simconfType *simconf;
+  SimconfType *simconf;
 }
 
 using namespace MyTRIM_NS;
 
-simconfType::simconfType(Real _alfa) :
+SimconfType::SimconfType(Real _alfa) :
     _data_dir(getenv("MYTRIM_DATADIR") ? getenv("MYTRIM_DATADIR") : MYTRIM_DATA_DIR)
 {
   ed = 25.0; // displacement energy
@@ -45,7 +45,7 @@ simconfType::simconfType(Real _alfa) :
 }
 
 void
-simconfType::readSnuc()
+SimconfType::readSnuc()
 {
   const unsigned int nbuf = 2000;
   char buffer[nbuf] = {0};
@@ -69,7 +69,7 @@ simconfType::readSnuc()
 }
 
 void
-simconfType::readScoef()
+SimconfType::readScoef()
 {
   const unsigned int nbuf = 2000;
   char buffer[nbuf] = {0};
@@ -113,7 +113,7 @@ simconfType::readScoef()
 }
 
 void
-simconfType::fileReadError(const char * path)
+SimconfType::fileReadError(const char * path)
 {
 #ifdef MYTRIM_ENABLED
     mooseError("Error reading " << path);
@@ -124,7 +124,7 @@ simconfType::fileReadError(const char * path)
 }
 
 void
-simconfType::skipLine(FILE * sf)
+SimconfType::skipLine(FILE * sf)
 {
   const unsigned int nbuf = 2000;
   char buffer[nbuf] = {0};

--- a/simconf.h
+++ b/simconf.h
@@ -44,22 +44,20 @@ typedef double Real;
 
 namespace MyTRIM_NS {
 
-// ZBL coefficients a,b,c,d for all element pairs from Z=1..92
-struct scoefLine {
-  char sym[3], name[30];
-  Real mm1, m1, mnat, rho, atrho, vfermi, heat, lfctr;
-};
-
-class simconfType
+class SimconfType
 {
 public:
-  simconfType(Real _alfa = 0.0);
+  SimconfType(Real _alfa = 0.0);
 
   Real ed, alfa, alpha, tmin, tau, da, cw;
   int id;
 
   // tables from files
-  scoefLine scoef[92];
+  // ZBL coefficients a,b,c,d for all element pairs from Z=1..92
+  struct ScoefLine {
+    char sym[3], name[30];
+    Real mm1, m1, mnat, rho, atrho, vfermi, heat, lfctr;
+  } scoef[92];
   Real pcoef[92][8];
   Real snuc[92][92][4];
 

--- a/trim.C
+++ b/trim.C
@@ -12,7 +12,7 @@ using namespace MyTRIM_NS;
 //
 
 // does a single ion cascade
-void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
+void trimBase::trim(IonBase *pka_, std::queue<IonBase*> &recoils)
 {
   // simconf should already be initialized
   pka = pka_;
@@ -260,7 +260,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     for (int i = 0; i < 3; i++) {
       if (sample->bc[i]==sampleBase::CUT &&
            (pka->pos(i)>sample->w[i] || pka->pos(i)<0.0)) {
-        pka->state = ionBase::LOST;
+        pka->state = IonBase::LOST;
         break;
       }
     }
@@ -268,7 +268,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     //
     // decide on the fate of recoil and pka
     //
-    if (pka->state != ionBase::LOST) {
+    if (pka->state != IonBase::LOST) {
       if (recoil->e > element->_Edisp) {
         // non-physics based descision on recoil following
         if (followRecoil()) {
@@ -283,7 +283,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
         } else {
           // this recoil could have left its lattice site, but we chose
           // not to follow it (simulation of PKAs only)
-          recoil->id = ionBase::DELETE;
+          recoil->id = IonBase::DELETE;
         }
 
         // will the knock-on get trapped at the recoil atom site?
@@ -295,24 +295,24 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
         } else {
           // nope, the pka gets stuck at that site as...
           if (pka->_Z == element->_Z)
-            pka->state = ionBase::REPLACEMENT;
+            pka->state = IonBase::REPLACEMENT;
           else
-            pka->state = ionBase::SUBSTITUTIONAL;
+            pka->state = IonBase::SUBSTITUTIONAL;
         }
       } else {
         // this recoil will not leave its lattice site
         dissipateRecoilEnergy();
-        recoil->id  = ionBase::DELETE;;
+        recoil->id  = IonBase::DELETE;;
 
         // if the PKA has no energy left, put it to rest here as an interstitial
         if (pka->e < pka->ef) {
-          pka->state = ionBase::INTERSTITIAL;
+          pka->state = IonBase::INTERSTITIAL;
         }
       }
     }
 
     // delete recoil if it was not queued
-    if (recoil->id  == ionBase::DELETE) delete recoil;
+    if (recoil->id  == IonBase::DELETE) delete recoil;
 
     // act on the pka state change
     checkPKAState();
@@ -321,7 +321,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     if (simconf->fullTraj)
       std::cout << pka->state << ' ' << *pka << std::endl;
 
-  } while (pka->state == ionBase::MOVING);
+  } while (pka->state == IonBase::MOVING);
 }
 
 void trimBase::vacancyCreation()

--- a/trim.C
+++ b/trim.C
@@ -345,7 +345,7 @@ void trimBase::vacancyCreation()
 
 
 /*
-materialBase* sampleType::lookupLayer(const Real* pos)
+MaterialBase* sampleType::lookupLayer(const Real* pos)
 {
   Real dif[3];
 

--- a/trim.C
+++ b/trim.C
@@ -258,7 +258,7 @@ void trimBase::trim(IonBase *pka_, std::queue<IonBase*> &recoils)
 
     // end cascade if a CUT boundary is crossed
     for (int i = 0; i < 3; i++) {
-      if (sample->bc[i]==sampleBase::CUT &&
+      if (sample->bc[i]==SampleBase::CUT &&
            (pka->pos(i)>sample->w[i] || pka->pos(i)<0.0)) {
         pka->state = IonBase::LOST;
         break;

--- a/trim.C
+++ b/trim.C
@@ -117,7 +117,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     hh = dr250(); // selects element inside material to scatter from
     for (nn = 0; nn < material->element.size(); ++nn)
     {
-      hh -= material->element[nn]->t;
+      hh -= material->element[nn]->_t;
       if (hh <= 0) break;
     }
     element = material->getElement(nn);
@@ -227,9 +227,9 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     recoil->e = den;
 
     // recoil loses the lattice binding energy
-    recoil->e -= element->Elbind;
-    recoil->_m = element->m;
-    recoil->_Z = element->z;
+    recoil->e -= element->_Elbind;
+    recoil->_m = element->_m;
+    recoil->_Z = element->_Z;
 
     // create a random vector perpendicular to pka.dir
     // there is a cleverer way by using the azimuthal angle of scatter...
@@ -269,7 +269,7 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
     // decide on the fate of recoil and pka
     //
     if (pka->state != ionBase::LOST) {
-      if (recoil->e > element->Edisp) {
+      if (recoil->e > element->_Edisp) {
         // non-physics based descision on recoil following
         if (followRecoil()) {
           v_norm(recoil->dir);
@@ -287,14 +287,14 @@ void trimBase::trim(ionBase *pka_, std::queue<ionBase*> &recoils)
         }
 
         // will the knock-on get trapped at the recoil atom site?
-        // (TODO: make sure that pka->ef < element->Edisp for all elements!)
+        // (TODO: make sure that pka->ef < element->_Edisp for all elements!)
         // did we create a vacancy by knocking out the recoil atom?
-        if (pka->e > element->Edisp) {
+        if (pka->e > element->_Edisp) {
           // yes, because the knock-on can escape, too!
           vacancyCreation();
         } else {
           // nope, the pka gets stuck at that site as...
-          if (pka->_Z == element->z)
+          if (pka->_Z == element->_Z)
             pka->state = ionBase::REPLACEMENT;
           else
             pka->state = ionBase::SUBSTITUTIONAL;
@@ -337,8 +337,8 @@ void trimBase::vacancyCreation()
     Real g = 3.4008 * std::pow(ed, 1.0/6.0) + 0.40244 * std::pow(ed, 3.0/4.0) + ed;
     Real kd = 0.1337 * std::pow(material->az, 2.0/3.0) / std::pow(material->am, 0.5); //Z,M
     Real Ev = recoil->e / (1.0 + kd * g);
-    simconf->KP_vacancies += 0.8 * Ev / (2.0 * element->Edisp);
-    // should be something like material->Edisp (average?)
+    simconf->KP_vacancies += 0.8 * Ev / (2.0 * element->_Edisp);
+    // should be something like material->_Edisp (average?)
   }
   */
 }

--- a/trim.C
+++ b/trim.C
@@ -12,7 +12,8 @@ using namespace MyTRIM_NS;
 //
 
 // does a single ion cascade
-void trimBase::trim(IonBase *pka_, std::queue<IonBase*> &recoils)
+void
+TrimBase::trim(IonBase *pka_, std::queue<IonBase*> &recoils)
 {
   // simconf should already be initialized
   pka = pka_;
@@ -324,7 +325,8 @@ void trimBase::trim(IonBase *pka_, std::queue<IonBase*> &recoils)
   } while (pka->state == IonBase::MOVING);
 }
 
-void trimBase::vacancyCreation()
+void
+TrimBase::vacancyCreation()
 {
   simconf->vacancies_created++;
 

--- a/trim.h
+++ b/trim.h
@@ -33,17 +33,17 @@ namespace MyTRIM_NS {
 
 class trimBase {
 public:
-  void trim(ionBase *pka, std::queue<ionBase*> &recoils);
+  void trim(IonBase *pka, std::queue<IonBase*> &recoils);
   trimBase(simconfType * simconf_, sampleBase *sample_) :
     simconf(simconf_), sample(sample_) {}
 
 protected:
   simconfType * simconf;
   sampleBase *sample;
-  ionBase *pka, *recoil;
+  IonBase *pka, *recoil;
   materialBase *material;
   ElementBase *element;
-  std::queue<ionBase*> *recoil_queue_ptr;
+  std::queue<IonBase*> *recoil_queue_ptr;
   bool terminate;
 
   // by default only follow recoils with E > 12eV
@@ -139,11 +139,11 @@ protected:
 
   // ions coming to rest
   virtual void checkPKAState() {
-    if (pka->state==ionBase::INTERSTITIAL)
+    if (pka->state==IonBase::INTERSTITIAL)
       os << "I " << *pka << std::endl;
-    else if (pka->state==ionBase::SUBSTITUTIONAL)
+    else if (pka->state==IonBase::SUBSTITUTIONAL)
       os << "S " << *pka << std::endl;
-    else if (pka->state==ionBase::REPLACEMENT)
+    else if (pka->state==IonBase::REPLACEMENT)
       os << "R " << *pka << std::endl;
   };
 };
@@ -194,8 +194,8 @@ protected:
 
   // residual energy of pka coming to a stop
   virtual void checkPKAState() {
-    if (pka->state == ionBase::MOVING ||
-        pka->state == ionBase::LOST) return;
+    if (pka->state == IonBase::MOVING ||
+        pka->state == IonBase::LOST) return;
 
     os << pka->e << ' ' <<  *pka << std::endl;
     simconf->EnucTotal += pka->e;

--- a/trim.h
+++ b/trim.h
@@ -34,11 +34,11 @@ namespace MyTRIM_NS {
 class trimBase {
 public:
   void trim(IonBase *pka, std::queue<IonBase*> &recoils);
-  trimBase(simconfType * simconf_, SampleBase *sample_) :
+  trimBase(SimconfType * simconf_, SampleBase *sample_) :
     simconf(simconf_), sample(sample_) {}
 
 protected:
-  simconfType * simconf;
+  SimconfType * simconf;
   SampleBase *sample;
   IonBase *pka, *recoil;
   MaterialBase *material;
@@ -67,7 +67,7 @@ protected:
 //
 class trimPrimaries : public trimBase {
 public:
-  trimPrimaries(simconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
+  trimPrimaries(SimconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
 protected:
   virtual int maxGen() { return 1; };
   virtual bool followRecoil() { return (recoil->gen < maxGen()); };
@@ -99,7 +99,7 @@ protected:
 //
 class trimRecoils : public trimPrimaries {
   public:
-    trimRecoils(simconfType * simconf_, SampleBase *sample_) : trimPrimaries(simconf_, sample_) {};
+    trimRecoils(SimconfType * simconf_, SampleBase *sample_) : trimPrimaries(simconf_, sample_) {};
   protected:
     virtual int maxGen() { return 2; };
 };
@@ -110,7 +110,7 @@ class trimRecoils : public trimPrimaries {
 //
 class trimHistory : public trimBase {
 public:
-  trimHistory(simconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
+  trimHistory(SimconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
   std::vector<Real> pos_hist[3];
 protected:
   virtual bool followRecoil()
@@ -128,7 +128,7 @@ protected:
 //
 class trimDefectLog : public trimBase {
 public:
-  trimDefectLog(simconfType * simconf_, SampleBase *sample_, std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
+  trimDefectLog(SimconfType * simconf_, SampleBase *sample_, std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
 protected:
   std::ostream &os;
 
@@ -156,7 +156,7 @@ class trimVacMap : public trimBase {
   static const int mx = 20, my = 20;
 public:
   int vmap[mx][my][3];
-  trimVacMap(simconfType * simconf_, SampleBase *sample_, int z1_, int z2_, int z3_ = -1) : trimBase(simconf_, sample_), z1(z1_), z2(z2_), z3(z3_)
+  trimVacMap(SimconfType * simconf_, SampleBase *sample_, int z1_, int z2_, int z3_ = -1) : trimBase(simconf_, sample_), z1(z1_), z2(z2_), z3(z3_)
   {
     for (int e = 0; e < 3; e++)
       for (int x = 0; x < mx; x++)
@@ -188,7 +188,7 @@ protected:
 //
 class trimPhononOut : public trimBase {
 public:
-  trimPhononOut(simconfType * simconf_, SampleBase *sample_,  std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
+  trimPhononOut(SimconfType * simconf_, SampleBase *sample_,  std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
 protected:
   std::ostream &os;
 

--- a/trim.h
+++ b/trim.h
@@ -42,7 +42,7 @@ protected:
   sampleBase *sample;
   ionBase *pka, *recoil;
   materialBase *material;
-  elementBase *element;
+  ElementBase *element;
   std::queue<ionBase*> *recoil_queue_ptr;
   bool terminate;
 
@@ -85,10 +85,10 @@ protected:
       Real g = 3.4008 * std::pow(ed, 1.0/6.0) + 0.40244 * std::pow(ed, 3.0/4.0) + ed;
       Real kd = 0.1337 * std::pow(material->az, 2.0/3.0) / std::pow(material->am, 0.5); //Z,M
       Real Ev = recoil->e / (1.0 + kd * g);
-      simconf->vacancies_created += int(0.8 * Ev / (2.0*element->Edisp));
+      simconf->vacancies_created += int(0.8 * Ev / (2.0*element->_Edisp));
 
       // TODO: this is missing the energy threshold of 2.5Ed!!!!
-      // TODO: should be something like material->Edisp (average?)
+      // TODO: should be something like material->_Edisp (average?)
     }
   }
 };
@@ -205,15 +205,15 @@ protected:
   // (make sure it keeps its binding enrgy and dissipate emeining E)
   virtual void dissipateRecoilEnergy()
   {
-    Real Edep = recoil->e + element->Elbind;
+    Real Edep = recoil->e + element->_Elbind;
     os << Edep << ' ' <<  *recoil << std::endl;
     simconf->EnucTotal += Edep;
   };
 
   // dissipate lattice binding energy where recoil branches off
   virtual bool followRecoil() {
-    os << element->Elbind << ' ' <<  *recoil << std::endl;
-    simconf->EnucTotal += element->Elbind;
+    os << element->_Elbind << ' ' <<  *recoil << std::endl;
+    simconf->EnucTotal += element->_Elbind;
     return true;
   }
 };

--- a/trim.h
+++ b/trim.h
@@ -34,12 +34,12 @@ namespace MyTRIM_NS {
 class trimBase {
 public:
   void trim(IonBase *pka, std::queue<IonBase*> &recoils);
-  trimBase(simconfType * simconf_, sampleBase *sample_) :
+  trimBase(simconfType * simconf_, SampleBase *sample_) :
     simconf(simconf_), sample(sample_) {}
 
 protected:
   simconfType * simconf;
-  sampleBase *sample;
+  SampleBase *sample;
   IonBase *pka, *recoil;
   MaterialBase *material;
   ElementBase *element;
@@ -67,7 +67,7 @@ protected:
 //
 class trimPrimaries : public trimBase {
 public:
-  trimPrimaries(simconfType * simconf_, sampleBase *sample_) : trimBase(simconf_, sample_) {};
+  trimPrimaries(simconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
 protected:
   virtual int maxGen() { return 1; };
   virtual bool followRecoil() { return (recoil->gen < maxGen()); };
@@ -99,7 +99,7 @@ protected:
 //
 class trimRecoils : public trimPrimaries {
   public:
-    trimRecoils(simconfType * simconf_, sampleBase *sample_) : trimPrimaries(simconf_, sample_) {};
+    trimRecoils(simconfType * simconf_, SampleBase *sample_) : trimPrimaries(simconf_, sample_) {};
   protected:
     virtual int maxGen() { return 2; };
 };
@@ -110,7 +110,7 @@ class trimRecoils : public trimPrimaries {
 //
 class trimHistory : public trimBase {
 public:
-  trimHistory(simconfType * simconf_, sampleBase *sample_) : trimBase(simconf_, sample_) {};
+  trimHistory(simconfType * simconf_, SampleBase *sample_) : trimBase(simconf_, sample_) {};
   std::vector<Real> pos_hist[3];
 protected:
   virtual bool followRecoil()
@@ -128,7 +128,7 @@ protected:
 //
 class trimDefectLog : public trimBase {
 public:
-  trimDefectLog(simconfType * simconf_, sampleBase *sample_, std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
+  trimDefectLog(simconfType * simconf_, SampleBase *sample_, std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
 protected:
   std::ostream &os;
 
@@ -156,7 +156,7 @@ class trimVacMap : public trimBase {
   static const int mx = 20, my = 20;
 public:
   int vmap[mx][my][3];
-  trimVacMap(simconfType * simconf_, sampleBase *sample_, int z1_, int z2_, int z3_ = -1) : trimBase(simconf_, sample_), z1(z1_), z2(z2_), z3(z3_)
+  trimVacMap(simconfType * simconf_, SampleBase *sample_, int z1_, int z2_, int z3_ = -1) : trimBase(simconf_, sample_), z1(z1_), z2(z2_), z3(z3_)
   {
     for (int e = 0; e < 3; e++)
       for (int x = 0; x < mx; x++)
@@ -188,7 +188,7 @@ protected:
 //
 class trimPhononOut : public trimBase {
 public:
-  trimPhononOut(simconfType * simconf_, sampleBase *sample_,  std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
+  trimPhononOut(simconfType * simconf_, SampleBase *sample_,  std::ostream &os_) : trimBase(simconf_, sample_), os(os_) {};
 protected:
   std::ostream &os;
 

--- a/trim.h
+++ b/trim.h
@@ -41,7 +41,7 @@ protected:
   simconfType * simconf;
   sampleBase *sample;
   IonBase *pka, *recoil;
-  materialBase *material;
+  MaterialBase *material;
   ElementBase *element;
   std::queue<IonBase*> *recoil_queue_ptr;
   bool terminate;


### PR DESCRIPTION
Fix case in class names. Reduce use of `struct` in favor of `class`. Start renaming member variables with leading `_`.

Refs #8
