### PR TITLE
The simplest NRT implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ install(FILES data/SCOEF.95A data/SCOEF.95B data/SLFCTR.dat data/SNUC03.dat data
 # build the test trim programs
 #
 include_directories(PUBLIC .)
-set(PROGRAMS mytrim_ODS mytrim_clusters mytrim_layers mytrim_solid mytrim_solid2 mytrim_uo2 mytrim_wire mytrim_dynamic mytrim_wire2 mytrim_bobmsq mytrim_moose_verification)
+set(PROGRAMS mytrim_ODS mytrim_clusters mytrim_layers mytrim_solid mytrim_solid2 mytrim_uo2 mytrim_wire mytrim_dynamic mytrim_wire2 mytrim_bobmsq mytrim_moose_verification mytrim_nrt)
 foreach(program ${PROGRAMS})
   add_executable(${program} apps/${program}.C)
   target_link_libraries(${program}  mytrim m)

--- a/apps/mytrim_nrt.C
+++ b/apps/mytrim_nrt.C
@@ -27,11 +27,6 @@ MaterialBase * _material;
 static const Real math_pi = 3.14159265359;
 static const Real electron_charge = 3.7941; // unit is sqrt(ev * A)
 
-// definitions for computing sigma_ij
-static const std::vector<Real> exponent_m = {1.0 / 3.0, 0.5, 1.0, 0.0};
-static const std::vector<Real> lambda_m = {1.309, 0.327, 0.5, 24.0};
-static const std::vector<Real> epsilon = {15.0, 0.369, 0.0234};
-
 // composition of the problem
 static const std::vector<std::string> names = {"C", "Si"};
 static const std::vector<Real> A = {12.0, 28.0};
@@ -40,7 +35,9 @@ static const std::vector<Real> f = {0.5, 0.5};
 static const std::vector<Real> displacement_threshold = {16.3, 92.6}; // from the paper
 
 // simulation parameters
-static const Real Emax = 1.0e5;
+static const Real Emax = 1.0e3;
+static const Real dE = 1.0;
+static const bool use_power_law = true;
 std::vector<Real> energy_nodes;
 std::vector<std::vector<std::vector<Real>>> nu;
 
@@ -87,7 +84,7 @@ ft(Real t)
 
 
 Real
-recoilCrossSection2(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
+recoilCrossSection(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
 {
   Real Tm = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]) * projectile_energy;
   if (target_energy > Tm)
@@ -99,46 +96,66 @@ recoilCrossSection2(Real projectile_energy, Real target_energy, unsigned int pro
   Real kappa = projectile_energy * A[projectile_id] / A[target_id] * sqr(a / (2.0 * zt * zp * sqr(electron_charge)));
   Real t = target_energy * kappa;
   Real eta = projectile_energy * A[projectile_id] / A[target_id] * sqr(a / (2.0 * zt * zp * sqr(electron_charge)));
-
   return 0.5 * math_pi * sqr(a) * kappa * ft(t) / pow(t, 3.0 / 2.0);
 }
 
-Real
-recoilCrossSection(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
+void
+getPieceWisePowerLaw(Real t, Real & alpha, Real & beta)
 {
-  // check if E->T combination is possible
-  Real gamma = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]);
-  if (target_energy > gamma * projectile_energy)
-    return 0;
-  Real zt = Z[target_id];
-  Real zp = Z[projectile_id];
-  Real a = 0.4683 / sqrt(pow(zt, 2.0 / 3.0) + pow(zp, 2.0 / 3.0));
-  Real eps = projectile_energy / (zt * zp * sqr(electron_charge) / a);
-
-  Real lambda, m;
-  if (eps < epsilon[2])
+  if (t <= 1.0e-5)
   {
-    m = exponent_m[3];
-    lambda = lambda_m[3];
+    alpha = 0;
+    beta = 1;
   }
-  else if (eps > epsilon[2] && eps < epsilon[1])
+  else if (t > 1.0e-5 && t <= 5.0e-3)
   {
-    m = exponent_m[2];
-    lambda = lambda_m[2];
+    alpha = -0.038867;
+    beta = 0.6285;
   }
-  else if (eps > epsilon[1] && eps < epsilon[0])
+  else if (t > 5.0e-3 && t <= 1.0e-1)
   {
-    m = exponent_m[1];
-    lambda = lambda_m[1];
+    alpha = -0.174285;
+    beta = 0.30668;
+  }
+  else if (t > 1.0e-1 && t <= 1.0)
+  {
+    alpha = -0.354466;
+    beta = 0.202539;
+  }
+  else if (t > 1.0    && t <= 10.0)
+  {
+    alpha = -0.50402;
+    beta = 0.2025388;
   }
   else
   {
-    m = exponent_m[0];
-    lambda = lambda_m[0];
+    alpha = -0.641031;
+    beta = 0.3075704;
   }
+}
 
-  Real Cm = 0.5 * math_pi * lambda * sqr(a) * A[projectile_id] / A[target_id] * pow(2.0 * zt * zp * sqr(electron_charge) / a, 2.0 * m);
-  return Cm * pow(projectile_energy, -m) * pow(target_energy, -1.0 - m);
+Real
+recoilCrossSectionPowerLaw(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
+{
+  Real Tm = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]) * projectile_energy;
+  if (target_energy > Tm)
+    return 0;
+
+  Real zt = Z[target_id];
+  Real zp = Z[projectile_id];
+  Real At = A[target_id];
+  Real Ap = A[projectile_id];
+  Real lambda = 1.309;
+  Real a0 = 0.4683;
+  Real Eref = 2.0 * sqr(electron_charge) / a0;
+  Real constant = 0.5 * math_pi * lambda * sqr(a0) / Eref;
+  Real Lpt = Ap / At / (sqr(zt * zp) * (pow(zt, 2.0 / 3.0) + pow(zp, 2.0 / 3.0)));
+  Real eps = projectile_energy / Eref;
+  Real tau = target_energy / Eref;
+  Real t =  Lpt * eps * tau;
+  Real alpha, beta;
+  getPieceWisePowerLaw(t, alpha, beta);
+  return constant * Lpt / (pow(zt, 2.0 / 3.0) + pow(zp, 2.0 / 3.0)) * eps * beta * pow(t, alpha - 4.0 / 3.0);
 }
 
 void
@@ -153,7 +170,10 @@ checkData()
   for (auto & e : energies)
   {
     for (auto & t : energies)
-        _console << recoilCrossSection2(e * 1.0e6, t * 1.0e6, 0, 0) << " ";
+      if (use_power_law)
+        _console << recoilCrossSectionPowerLaw(e, t, 0, 0) << " ";
+      else
+        _console << recoilCrossSection(e, t, 0, 0) << " ";
     _console << std::endl;
   }
 }
@@ -189,8 +209,12 @@ nuclearStopping(unsigned int projectile_id, unsigned int target_id, unsigned int
   {
     if (energy_nodes[ll] > Lij * energy_nodes[l])
       return integral;
-    integral += getDeltaE(l) * energy_nodes[ll]
-             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+    Real xs;
+    if (use_power_law)
+      xs = recoilCrossSectionPowerLaw(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+    else
+      xs = recoilCrossSection(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+    integral += getDeltaE(l) * energy_nodes[ll] * xs;
   }
   return integral;
 }
@@ -211,8 +235,14 @@ integralI(unsigned int projectile_id, unsigned int target_id, unsigned int l)
     if (energy_nodes[ll] > Lij * energy_nodes[l])
       return integral;
 
+    Real xs;
+    if (use_power_law)
+      xs = recoilCrossSectionPowerLaw(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+    else
+      xs = recoilCrossSection(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+
     if (energy_nodes[ll] > displacement_threshold[target_id])
-      integral += getDeltaE(ll) * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+      integral += getDeltaE(ll) * xs;
   }
   return integral;
 }
@@ -233,14 +263,18 @@ integralII(unsigned int projectile_id, unsigned int target_id, unsigned int k, u
     if (energy_nodes[ll] > Lik * energy_nodes[l])
       return integral;
 
+    Real xs;
+    if (use_power_law)
+      xs = recoilCrossSectionPowerLaw(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+    else
+      xs = recoilCrossSection(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+
     if (ll == l)
       // in this case we don't know the nu at energy l since we are just computing it.
       // constant approximation consistent with forward Euler tells us to use value at l-1
-      integral += getDeltaE(ll) * nu[k][target_id][ll - 1]
-               * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+      integral += getDeltaE(ll) * nu[k][target_id][ll - 1] * xs;
     else if (ll != l && energy_nodes[ll] > displacement_threshold[target_id])
-      integral += getDeltaE(ll) * nu[k][target_id][ll]
-               * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+      integral += getDeltaE(ll) * nu[k][target_id][ll] * xs;
   }
   return integral;
 }
@@ -265,12 +299,17 @@ integralIII(unsigned int projectile_id, unsigned int target_id, unsigned int k, 
     if (Ediff - displacement_threshold[target_id] / Lij < 0.0)
       continue;
 
+    Real xs;
+    if (use_power_law)
+      xs = recoilCrossSectionPowerLaw(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+    else
+      xs = recoilCrossSection(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+
     // find interpolated nu => simply take the value from the left
     unsigned int index = findIndex(Ediff);
     Real interpolated_nu = nu[projectile_id][target_id][index];
 
-    integral += getDeltaE(ll) * interpolated_nu
-             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+    integral += getDeltaE(ll) * interpolated_nu * xs;
   }
   return integral;
 }
@@ -287,8 +326,13 @@ integralIV(unsigned int projectile_id, unsigned int target_id, unsigned int k, u
     if (energy_nodes[ll] > Lik * energy_nodes[l])
       return integral;
 
-    integral += getDeltaE(ll) * nu[projectile_id][target_id][l - 1]
-             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+      Real xs;
+      if (use_power_law)
+        xs = recoilCrossSectionPowerLaw(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+      else
+        xs = recoilCrossSection(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+
+    integral += getDeltaE(ll) * nu[projectile_id][target_id][l - 1] * xs;
   }
   return integral;
 }
@@ -342,10 +386,9 @@ main()
   _material = new MaterialBase(_simconf, 1.0);
 
   // check out data
-  // checkData();
+  //checkData();
 
   // set up energy_nodes: assume equal spacing
-  Real dE = 10.0;
   Real Ec = 0.0;
   while (Ec < Emax)
   {

--- a/apps/mytrim_nrt.C
+++ b/apps/mytrim_nrt.C
@@ -1,0 +1,380 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <queue>
+
+#include "simconf.h"
+#include "element.h"
+#include "material.h"
+#include "sample_wire.h"
+#include "ion.h"
+#include "trim.h"
+#include "invert.h"
+
+#include "functions.h"
+
+using namespace MyTRIM_NS;
+
+#define _console std:: cout
+
+SimconfType * _simconf;
+MaterialBase * _material;
+
+// some useful constants
+static const Real math_pi = 3.14159265359;
+static const Real electron_charge = 3.7941; // unit is sqrt(ev * A)
+
+// definitions for computing sigma_ij
+static const std::vector<Real> exponent_m = {1.0 / 3.0, 0.5, 1.0, 0.0};
+static const std::vector<Real> lambda_m = {1.309, 0.327, 0.5, 24.0};
+static const std::vector<Real> epsilon = {15.0, 0.369, 0.0234};
+
+// composition of the problem
+static const std::vector<std::string> names = {"C", "Si"};
+static const std::vector<Real> A = {12.0, 28.0};
+static const std::vector<Real> Z = {6.0, 14.0};
+static const std::vector<Real> f = {0.5, 0.5};
+static const std::vector<Real> displacement_threshold = {16.3, 92.6}; // from the paper
+
+// simulation parameters
+static const Real Emax = 1.0e5;
+std::vector<Real> energy_nodes;
+std::vector<std::vector<std::vector<Real>>> nu;
+
+Real
+stoppingPower(Real projectile_energy, unsigned int projectile_id)
+{
+  Real stopping_power = 0.0;
+  Real weight = 0.0;
+
+  // loop over all species and accumulate Se_composite using Bragg's Additivity rule
+  IonBase * ion;
+  for (unsigned int target_id = 0; target_id < A.size(); ++target_id)
+  {
+    // populate ion
+    ion = new MyTRIM_NS::IonBase;
+    ion->_gen = 0;
+    ion->_tag = 0;
+    ion->_Z = Z[projectile_id];
+    ion->_m = A[projectile_id];
+    ion->_E  = projectile_energy;
+
+    ion->_dir(0) = 0.0;
+    ion->_dir(1) = 1.0;
+    ion->_dir(2) = 0.0;
+
+    ion->_pos(0) = 0;
+    ion->_pos(1) = 0;
+    ion->_pos(2) = 0;
+
+    int z2 = Z[target_id];
+    Real s = _material->rstop(ion, z2);
+    stopping_power += s * A[target_id] * f[target_id];
+    weight += A[target_id] * f[target_id];
+  }
+  return stopping_power / weight;
+}
+
+Real
+ft(Real t)
+{
+  Real lambda = 1.309;
+  return lambda * pow(t, 1.0 / 6.0) * pow(1.0 + pow(2.0 * lambda * pow(t, 2.0 / 3.0), 2.0 / 3.0), -3.0 / 2.0);
+}
+
+
+Real
+recoilCrossSection2(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
+{
+  Real Tm = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]) * projectile_energy;
+  if (target_energy > Tm)
+    return 0;
+
+  Real zt = Z[target_id];
+  Real zp = Z[projectile_id];
+  Real a = 0.4683 / sqrt(pow(zt, 2.0 / 3.0) + pow(zp, 2.0 / 3.0));
+  Real kappa = projectile_energy * A[projectile_id] / A[target_id] * sqr(a / (2.0 * zt * zp * sqr(electron_charge)));
+  Real t = target_energy * kappa;
+  Real eta = projectile_energy * A[projectile_id] / A[target_id] * sqr(a / (2.0 * zt * zp * sqr(electron_charge)));
+
+  return 0.5 * math_pi * sqr(a) * kappa * ft(t) / pow(t, 3.0 / 2.0);
+}
+
+Real
+recoilCrossSection(Real projectile_energy, Real target_energy, unsigned int projectile_id, unsigned int target_id)
+{
+  // check if E->T combination is possible
+  Real gamma = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]);
+  if (target_energy > gamma * projectile_energy)
+    return 0;
+  Real zt = Z[target_id];
+  Real zp = Z[projectile_id];
+  Real a = 0.4683 / sqrt(pow(zt, 2.0 / 3.0) + pow(zp, 2.0 / 3.0));
+  Real eps = projectile_energy / (zt * zp * sqr(electron_charge) / a);
+
+  Real lambda, m;
+  if (eps < epsilon[2])
+  {
+    m = exponent_m[3];
+    lambda = lambda_m[3];
+  }
+  else if (eps > epsilon[2] && eps < epsilon[1])
+  {
+    m = exponent_m[2];
+    lambda = lambda_m[2];
+  }
+  else if (eps > epsilon[1] && eps < epsilon[0])
+  {
+    m = exponent_m[1];
+    lambda = lambda_m[1];
+  }
+  else
+  {
+    m = exponent_m[0];
+    lambda = lambda_m[0];
+  }
+
+  Real Cm = 0.5 * math_pi * lambda * sqr(a) * A[projectile_id] / A[target_id] * pow(2.0 * zt * zp * sqr(electron_charge) / a, 2.0 * m);
+  return Cm * pow(projectile_energy, -m) * pow(target_energy, -1.0 - m);
+}
+
+void
+checkData()
+{
+  std::vector<Real> energies = {0.15, 0.192, 0.24, 0.3, 0.384, 0.48, 0.6, 0.72, 0.84, 0.96, 1.08, 1.2,
+                                1.5, 1.92, 2.4, 3.0, 3.84, 4.8, 6.0, 7.2, 8.4, 9.6, 10.8};
+  for (auto & e : energies)
+    _console << e << " MeV " << stoppingPower(e * 1.0e6, 0) / (10.0 * 19.94) << std::endl;
+
+  _console << std::endl;
+  for (auto & e : energies)
+  {
+    for (auto & t : energies)
+        _console << recoilCrossSection2(e * 1.0e6, t * 1.0e6, 0, 0) << " ";
+    _console << std::endl;
+  }
+}
+
+unsigned int
+findIndex(Real energy)
+{
+  for (unsigned int ll = 0; ll < energy_nodes.size() - 1; ++ll)
+    if (energy_nodes[ll + 1] > energy)
+      return ll;
+  return energy_nodes.size() - 1;
+}
+
+Real
+getDeltaE(unsigned int l)
+{
+  if (l == 0)
+    return 0.5 * energy_nodes[1]; // energy_nodes[0] = 0
+  else if (l == energy_nodes.size() - 1)
+    return 0.5 * (energy_nodes[l] - energy_nodes[l - 1]);
+  return 0.5 * (energy_nodes[l + 1] - energy_nodes[l - 1]);
+}
+
+// computes the nuclear stopping power from sigma
+Real
+nuclearStopping(unsigned int projectile_id, unsigned int target_id, unsigned int l)
+{
+  Real integral = 0;
+  Real Lij = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]);
+
+  // loop over all energies; E_0 = 0 < Ejd
+  for (unsigned int ll = 1; ll < energy_nodes.size(); ++ll)
+  {
+    if (energy_nodes[ll] > Lij * energy_nodes[l])
+      return integral;
+    integral += getDeltaE(l) * energy_nodes[ll]
+             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+  }
+  return integral;
+}
+
+Real
+integralI(unsigned int projectile_id, unsigned int target_id, unsigned int l)
+{
+  Real integral = 0;
+  Real Lij = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]);
+
+  // check easy way out
+  if (energy_nodes[l] < displacement_threshold[target_id])
+    return 0;
+
+  // loop over all energies; E_0 = 0 < Ejd
+  for (unsigned int ll = 1; ll < energy_nodes.size(); ++ll)
+  {
+    if (energy_nodes[ll] > Lij * energy_nodes[l])
+      return integral;
+
+    if (energy_nodes[ll] > displacement_threshold[target_id])
+      integral += getDeltaE(ll) * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, target_id);
+  }
+  return integral;
+}
+
+Real
+integralII(unsigned int projectile_id, unsigned int target_id, unsigned int k, unsigned int l)
+{
+  Real integral = 0;
+  Real Lik = 4.0 * A[k] * A[projectile_id] / sqr(A[k] + A[projectile_id]);
+
+  // check easy way out
+  if (energy_nodes[l] < displacement_threshold[target_id])
+    return 0;
+
+  // loop over all energies; E_0 = 0 implies nu_ij = 0
+  for (unsigned int ll = 1; ll < energy_nodes.size(); ++ll)
+  {
+    if (energy_nodes[ll] > Lik * energy_nodes[l])
+      return integral;
+
+    if (ll == l)
+      // in this case we don't know the nu at energy l since we are just computing it.
+      // constant approximation consistent with forward Euler tells us to use value at l-1
+      integral += getDeltaE(ll) * nu[k][target_id][ll - 1]
+               * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+    else if (ll != l && energy_nodes[ll] > displacement_threshold[target_id])
+      integral += getDeltaE(ll) * nu[k][target_id][ll]
+               * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+  }
+  return integral;
+}
+
+Real
+integralIII(unsigned int projectile_id, unsigned int target_id, unsigned int k, unsigned int l)
+{
+  Real integral = 0;
+  Real Lik = 4.0 * A[k] * A[projectile_id] / sqr(A[k] + A[projectile_id]);
+  Real Lij = 4.0 * A[target_id] * A[projectile_id] / sqr(A[target_id] + A[projectile_id]);
+
+  // we cannot allow T = 0 because the scattering XS blows up
+  // in this case no energy is lost so this is an uninteresting event (is that true)?
+  for (unsigned int ll = 1; ll < energy_nodes.size(); ++ll)
+  {
+    if (energy_nodes[ll] > Lik * energy_nodes[l])
+      return integral;
+
+    Real Ediff = energy_nodes[l] - energy_nodes[ll];
+
+    // this takes care of the heavyside step function!
+    if (Ediff - displacement_threshold[target_id] / Lij < 0.0)
+      continue;
+
+    // find interpolated nu => simply take the value from the left
+    unsigned int index = findIndex(Ediff);
+    Real interpolated_nu = nu[projectile_id][target_id][index];
+
+    integral += getDeltaE(ll) * interpolated_nu
+             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+  }
+  return integral;
+}
+
+Real
+integralIV(unsigned int projectile_id, unsigned int target_id, unsigned int k, unsigned int l)
+{
+  Real integral = 0;
+  Real Lik = 4.0 * A[k] * A[projectile_id] / sqr(A[k] + A[projectile_id]);
+
+  // loop over all energies; E_0 = 0 < Ejd
+  for (unsigned int ll = 1; ll < energy_nodes.size(); ++ll)
+  {
+    if (energy_nodes[ll] > Lik * energy_nodes[l])
+      return integral;
+
+    integral += getDeltaE(ll) * nu[projectile_id][target_id][l - 1]
+             * recoilCrossSection2(energy_nodes[l], energy_nodes[ll], projectile_id, k);
+  }
+  return integral;
+}
+
+Real
+nrtRightHandSide(unsigned int projectile_id, unsigned int target_id, unsigned int l)
+{
+  Real fijl = 0;
+  // loop over k as in Eq. (7)
+  for (unsigned int k = 0; k < A.size(); ++k)
+  {
+    // NOTE: j == k!
+    // integralI = integral_Ejd^{Lambda_ij * E_l} dT sigma_ij(E,T)
+    if (target_id == k)
+      fijl += f[k] * integralI(projectile_id, target_id, l);
+
+    // integralII_ijkl = integral_{Ekd}^{Lambda_ik E_l} dT nu_kj * sigma_ik(E_l, T)
+    fijl += f[k] * integralII(projectile_id, target_id, k, l);
+
+    // integralIII_ijkl = integral_{0}^{Lambda_ik} Gamma(E-T-Ejd/Lambda_ij) nu_ij(E_l - T) sigma_ik(E_l, T) dT
+    fijl += f[k] * integralIII(projectile_id, target_id, k, l);
+
+    // integralIV_ijkl = integral_{0}^{Lambda_ij * E_l} sigma_ik(E_l, T) * vij(E) dT
+    // Note: it's subtracted!
+    fijl -= f[k] * integralIV(projectile_id, target_id, k, l);
+  }
+  return fijl;
+}
+
+void
+takeNRTStep(unsigned int l)
+{
+  for (unsigned int projectile_id = 0; projectile_id < A.size(); ++projectile_id)
+    for (unsigned int target_id = 0; target_id < A.size(); ++target_id)
+    {
+      Real stopping_power = stoppingPower(energy_nodes[l], projectile_id);
+      Real deltaE = energy_nodes[l] - energy_nodes[l - 1];
+      nu[projectile_id][target_id][l] = nu[projectile_id][target_id][l - 1] + deltaE / stopping_power
+                                      * nrtRightHandSide(projectile_id, target_id, l);
+    }
+}
+
+int
+main()
+{
+  unsigned int seed = 1;
+
+  // initialize global parameter structure and read data tables from file
+  _simconf = new SimconfType(seed);
+
+  _material = new MaterialBase(_simconf, 1.0);
+
+  // check out data
+  // checkData();
+
+  // set up energy_nodes: assume equal spacing
+  Real dE = 10.0;
+  Real Ec = 0.0;
+  while (Ec < Emax)
+  {
+    energy_nodes.push_back(Ec);
+    Ec += dE;
+  }
+
+  // set up nu
+  nu.resize(A.size());
+  for (unsigned int j = 0; j < A.size(); ++j)
+  {
+    nu[j].resize(A.size());
+    for (unsigned int k = 0; k < A.size(); ++k)
+      nu[j][k].resize(energy_nodes.size());
+  }
+
+  // step through all times and compute nu_ij for that time
+  // Note: no need to work on l = 0 since nu_ij = 0
+  for (unsigned int l = 1; l < energy_nodes.size(); ++l)
+    takeNRTStep(l);
+
+  for (unsigned int l = 0; l < energy_nodes.size(); ++l)
+  {
+    for (unsigned int i = 0; i < A.size(); ++i)
+      for (unsigned int j = 0; j < A.size(); ++j)
+        _console << energy_nodes[l] << " " << nu[i][j][l] << " ";
+    _console << std::endl;
+  }
+
+  delete _simconf;
+  delete _material;
+}

--- a/material.h
+++ b/material.h
@@ -63,9 +63,10 @@ public:
 
   std::vector<Element> _element;
 
+  Real rstop(const IonBase *ion, int z2);
+
 protected:
   Real rpstop(int z2, Real e);
-  Real rstop(const IonBase *ion, int z2);
 
   SimconfType * _simconf;
 };


### PR DESCRIPTION
This is in relatively good agreement with the paper [note I stopped at 1e5 eV!]. Some noteworthy items:

1. it scales quadratic with number of energy nodes. It's really slow in fact.
2. uses forward Euler and constant approximations wherever applicable.
3. execution time for creating the data for the graph ~5-10 minutes.
4. sorry for the cheap-and-dirty plots...

![screen shot 2017-04-12 at 11 34 02 am](https://cloud.githubusercontent.com/assets/7524371/24971105/ff87a2e6-1f73-11e7-9fad-5bde649f883c.png)


![screen shot 2017-04-12 at 11 28 49 am](https://cloud.githubusercontent.com/assets/7524371/24971005/94636338-1f73-11e7-8d3f-1e1192781a76.png)
