### PR TITLE
Error out if cli arguments are provided

### DIFF
--- a/apps/runmytrim.C
+++ b/apps/runmytrim.C
@@ -93,8 +93,12 @@ computeThread(int tid)
 }
 
 int
-main()
+main(int argc, char * argv[])
 {
+  // error out if any cli args have been passed in
+  if (argc > 1)
+    mytrimError("Please supply the input file via stdin (e.g. ./runmytrim < input.json`)");
+
   // open the input
   Json::Value json_root;
   std::cin >> json_root;

--- a/apps/runstopping.C
+++ b/apps/runstopping.C
@@ -54,8 +54,12 @@ using namespace MyTRIM_NS;
   } while (0)
 
 int
-main()
+main(int argc, char * argv[])
 {
+  // error out if any cli args have been passed in
+  if (argc > 1)
+    mytrimError("Please supply the input file via stdin (e.g. ./runstopping < input.json`)");
+
   // open the input
   Json::Value json_root;
   std::cin >> json_root;


### PR DESCRIPTION
Make sure 

```
./runmytrim input.i
``` 

errors out immediately and prints the correct usage 

```
./runmytrim < input.i
```